### PR TITLE
fix the imaplib error with python3.9

### DIFF
--- a/tlslite/integration/imap4_tls.py
+++ b/tlslite/integration/imap4_tls.py
@@ -82,13 +82,16 @@ class IMAP4_TLS(IMAP4, ClientHelper):
 
         IMAP4.__init__(self, host, port)
 
-
-    def open(self, host = '', port = IMAP4_TLS_PORT):
+    # the `timeout` is a new argument in python3.9, so checks with
+    # older python versions will complain about unmatched parameters
+    # pylint: disable=arguments-differ
+    def open(self, host='', port=IMAP4_TLS_PORT, timeout=None):
         """Setup connection to remote server on "host:port".
 
         This connection will be used by the routines:
         read, readline, send, shutdown.
         """
+        del timeout
         self.host = host
         self.port = port
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -96,3 +99,4 @@ class IMAP4_TLS(IMAP4, ClientHelper):
         self.sock = TLSConnection(self.sock)
         ClientHelper._handshake(self, self.sock)
         self.file = self.sock.makefile('rb')
+    # pylint: enable=arguments-differ


### PR DESCRIPTION
fixes the
```
  File "/home/hkario/dev/tlslite-2/tlslite/integration/imap4_tls.py", line 83, in __init__
    IMAP4.__init__(self, host, port)
  File "/usr/lib64/python3.9/imaplib.py", line 202, in __init__
    self.open(host, port, timeout)
TypeError: open() takes from 1 to 3 positional arguments but 4 were given
```
error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/434)
<!-- Reviewable:end -->
