### PR TITLE
Implementation of RFC5077 SessionTickets resumption.

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -324,19 +324,19 @@ def handleArgs(argv, argString, flagsList=[]):
 def printGoodConnection(connection, seconds):
     print("  Handshake time: %.3f seconds" % seconds)
     print("  Version: %s" % connection.getVersionName())
-    print("  Cipher: %s %s" % (connection.getCipherName(), 
+    print("  Cipher: %s %s" % (connection.getCipherName(),
         connection.getCipherImplementation()))
     print("  Ciphersuite: {0}".\
             format(CipherSuite.ietfNames[connection.session.cipherSuite]))
     if connection.session.srpUsername:
         print("  Client SRP username: %s" % connection.session.srpUsername)
     if connection.session.clientCertChain:
-        print("  Client X.509 SHA1 fingerprint: %s" % 
+        print("  Client X.509 SHA1 fingerprint: %s" %
             connection.session.clientCertChain.getFingerprint())
     else:
         print("  No client certificate provided by peer")
     if connection.session.serverCertChain:
-        print("  Server X.509 SHA1 fingerprint: %s" % 
+        print("  Server X.509 SHA1 fingerprint: %s" %
             connection.session.serverCertChain.getFingerprint())
     if connection.version >= (3, 3) and connection.serverSigAlg is not None:
         scheme = SignatureScheme.toRepr(connection.serverSigAlg)
@@ -352,20 +352,21 @@ def printGoodConnection(connection, seconds):
         print("  DH group size: {0} bits".format(connection.dhGroupSize))
     if connection.session.serverName:
         print("  SNI: %s" % connection.session.serverName)
-    if connection.session.tackExt:   
+    if connection.session.tackExt:
         if connection.session.tackInHelloExt:
             emptyStr = "\n  (via TLS Extension)"
         else:
-            emptyStr = "\n  (via TACK Certificate)" 
+            emptyStr = "\n  (via TACK Certificate)"
         print("  TACK: %s" % emptyStr)
         print(str(connection.session.tackExt))
     if connection.session.appProto:
         print("  Application Layer Protocol negotiated: {0}".format(
             connection.session.appProto.decode('utf-8')))
-    print("  Next-Protocol Negotiated: %s" % connection.next_proto) 
+    print("  Next-Protocol Negotiated: %s" % connection.next_proto)
     print("  Encrypt-then-MAC: {0}".format(connection.encryptThenMAC))
     print("  Extended Master Secret: {0}".format(
                                                connection.extendedMasterSecret))
+    print("  Session Resumed: {0}".format(connection.resumed))
 
 def printExporter(connection, expLabel, expLength):
     if expLabel is None:
@@ -464,11 +465,8 @@ def clientCmd(argv):
     # unreasumable, override it
     session.resumable = True
 
-    print("Received {0} ticket[s]".format(len(connection.tickets)))
+    print("Received {0} ticket[s]".format(len(connection.tickets) + len(connection.tls_1_0_tickets)))
     assert connection.tickets is session.tickets
-
-    if not session.tickets:
-        return
 
     if not resumption:
         return
@@ -480,11 +478,10 @@ def clientCmd(argv):
     sock.connect(address)
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     connection = TLSConnection(sock)
-
     try:
         start = time_stamp()
         connection.handshakeClientCert(serverName=address[0], alpn=alpn,
-            session=session)
+            session=session, settings=settings)
         stop = time_stamp()
         print("Handshake success")
     except TLSLocalAlert as a:

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -169,6 +169,7 @@ class ExtensionType(TLSEnum):
     encrypt_then_mac = 22  # RFC 7366
     extended_master_secret = 23  # RFC 7627
     record_size_limit = 28  # RFC 8449
+    session_ticket = 35 # RFC 5077
     extended_random = 40  # draft-rescorla-tls-extended-random-02
     pre_shared_key = 41  # TLS 1.3
     early_data = 42  # TLS 1.3

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -2111,6 +2111,53 @@ class RecordSizeLimitExtension(IntExtension):
             2, 'record_size_limit', ExtensionType.record_size_limit)
 
 
+class SessionTicketExtension(TLSExtension):
+    """
+    Client and server session ticket extension from RFC 5077
+    """
+    def __init__(self):
+        """Create instance of the object."""
+        super(SessionTicketExtension, self).__init__(extType=ExtensionType.
+                                                     session_ticket)
+        self.ticket = None
+
+    def create(self, ticket):
+
+        self.ticket = ticket
+        return self
+
+    @property
+    def extData(self):
+        """Serialise the payload of the extension."""
+        if not self.ticket:
+            return bytearray(0)
+
+        w = Writer()
+        w.bytes += self.ticket
+        return w.bytes
+
+    def parse(self, parser):
+        """
+        Parse the extension from on the wire format.
+
+        :param Parser parser: data to be parsed
+
+        :rtype: SessionTicketExtension
+        """
+        if not parser.getRemainingLength():
+            self.ticket = bytearray(0)
+            return self
+        self.ticket = parser.getFixBytes(parser.getRemainingLength())
+
+        return self
+
+    def __repr__(self):
+        """Return human readable representation of the extension."""
+        return "{0}({1}={2!r})".format(self.__class__.__name__,
+                                       "ticket",
+                                       self.ticket)
+
+
 TLSExtension._universalExtensions = \
     {
         ExtensionType.server_name: SNIExtension,
@@ -2132,7 +2179,8 @@ TLSExtension._universalExtensions = \
         ExtensionType.pre_shared_key: PreSharedKeyExtension,
         ExtensionType.psk_key_exchange_modes: PskKeyExchangeModesExtension,
         ExtensionType.cookie: CookieExtension,
-        ExtensionType.record_size_limit: RecordSizeLimitExtension}
+        ExtensionType.record_size_limit: RecordSizeLimitExtension,
+        ExtensionType.session_ticket: SessionTicketExtension}
 
 TLSExtension._serverExtensions = \
     {

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -321,6 +321,11 @@ class HandshakeSettings(object):
     :ivar ticketLifetime: maximum allowed lifetime of ticket encryption key,
         in seconds. 1 day by default
 
+    :vartype ticket_count: int
+    :ivar ticket_count: number of tickets the server will send to the client
+        after establishing the connection in TLS 1.3. If a positive integer,
+        it enabled support for ticket based resumption in TLS 1.2 and earlier.
+
     :vartype psk_modes: list(str)
     :ivar psk_modes: acceptable modes for the PSK key exchange in TLS 1.3
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -2070,11 +2070,51 @@ class NewSessionTicket(HelloMessage):
         return self
 
 
+class NewSessionTicket1_0(HelloMessage):
+    """Handling of the TLS1.0-TLS1.2 NewSessionTicket message."""
+
+    def __init__(self):
+        """Create New Session Ticket object."""
+        super(NewSessionTicket1_0, self).__init__(HandshakeType
+                                                  .new_session_ticket)
+        self.ticket_lifetime = 0
+        self.ticket = bytearray(0)
+
+    def create(self, ticket_lifetime, ticket):
+        """Initialise a New Session Ticket."""
+        self.ticket_lifetime = ticket_lifetime
+        self.ticket = ticket
+        return self
+
+    def write(self):
+        """
+        Serialise the message to on the wire data.
+
+        :rtype: bytearray
+        """
+        w = Writer()
+        w.add(self.ticket_lifetime, 4)
+        w.addVarSeq(self.ticket, 1, 2)
+        w2 = Writer()
+        w.bytes += w2.bytes
+
+        return self.postWrite(w)
+
+    def parse(self, parser):
+        """Parse the object from on the wire data."""
+        parser.startLengthCheck(3)
+        self.ticket_lifetime = parser.get(4)
+        self.ticket = parser.getVarBytes(2)
+        parser.stopLengthCheck()
+
+        return self
+
+
 class SessionTicketPayload(object):
     """Serialisation and deserialisation of server state for resumption.
 
     This is the internal (meant to be encrypted) representation of server
-    state that is set to client in the NewSessionTicket message.
+    state that is sent to the client in the NewSessionTicket message.
 
     :ivar int ~.version: implementation detail for forward compatibility
     :ivar bytearray master_secret: master secret for TLS 1.2-, resumption
@@ -2090,6 +2130,10 @@ class SessionTicketPayload(object):
 
     :ivar int creation_time: Unix time in seconds when was the ticket created
     :ivar X509CertChain client_cert_chain: Client X509 Certificate Chain
+    :ivar bool encrypt_then_mac: The session used the encrypt_then_mac
+        extension
+    :ivar bool extended_master_secret: The session used the
+        extended_master_secret extension
     """
 
     def __init__(self):
@@ -2101,6 +2145,9 @@ class SessionTicketPayload(object):
         self.creation_time = 0
         self.nonce = bytearray()
         self._cert_chain = None
+        self.encrypt_then_mac = False
+        self.extended_master_secret = False
+        self.server_name = bytearray()
 
     @property
     def client_cert_chain(self):
@@ -2117,7 +2164,9 @@ class SessionTicketPayload(object):
                             .create(i, []) for i in client_cert_chain.x509List]
 
     def create(self, master_secret, protocol_version, cipher_suite,
-               creation_time, nonce=bytearray(), client_cert_chain=None):
+               creation_time, nonce=bytearray(), client_cert_chain=None,
+               encrypt_then_mac=False, extended_master_secret=False,
+               server_name=bytearray()):
         """Initialise the object with cryptographic data."""
         self.master_secret = master_secret
         self.protocol_version = protocol_version
@@ -2127,6 +2176,16 @@ class SessionTicketPayload(object):
         if client_cert_chain:
             self.version = 1
             self.client_cert_chain = client_cert_chain
+        if encrypt_then_mac or extended_master_secret or server_name:
+            if self.client_cert_chain is None:
+                self._cert_chain = []
+            self.version = 2
+            self.encrypt_then_mac = encrypt_then_mac
+            self.extended_master_secret = extended_master_secret
+            if server_name is None:
+                self.server_name = bytearray()
+            else:
+                self.server_name = server_name
         return self
 
     def _parse_cert_chain(self, parser):
@@ -2137,15 +2196,19 @@ class SessionTicketPayload(object):
 
     def parse(self, parser):
         self.version = parser.get(2)
-        if self.version > 1:
+        if self.version > 2:
             raise ValueError("Unrecognised version number")
         self.master_secret = parser.getVarBytes(2)
         self.protocol_version = (parser.get(1), parser.get(1))
         self.cipher_suite = parser.get(2)
         self.nonce = parser.getVarBytes(1)
         self.creation_time = parser.get(8)
-        if self.version == 1:
+        if self.version >= 1:
             self._parse_cert_chain(Parser(parser.getVarBytes(3)))
+        if self.version >= 2:
+            self.encrypt_then_mac = bool(parser.get(1))
+            self.extended_master_secret = bool(parser.get(1))
+            self.server_name = parser.getVarBytes(2)
         if parser.getRemainingLength():
             raise ValueError("Malformed ticket")
         return self
@@ -2161,11 +2224,16 @@ class SessionTicketPayload(object):
         writer.addOne(len(self.nonce))
         writer.bytes += self.nonce
         writer.add(self.creation_time, 8)
-        if self.version == 1:
+        if self.version >= 1:
             wcert = Writer()
             for entry in self._cert_chain:
                 wcert.bytes += entry.write()
             writer.addVarSeq(wcert.bytes, 1, 3)
+        if self.version >= 2:
+            writer.addOne(int(self.encrypt_then_mac))
+            writer.addOne(int(self.extended_master_secret))
+            writer.addTwo(len(self.server_name))
+            writer.bytes += self.server_name
         return writer.bytes
 
 

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -360,6 +360,13 @@ class RecordLayer(object):
         self._pendingWriteState.encryptThenMAC = value
         self._pendingReadState.encryptThenMAC = value
 
+    def _get_pending_state_etm(self):
+        """
+        Return the state of encrypt then MAC for the connection after
+        CCS will be exchanged
+        """
+        return self._pendingWriteState.encryptThenMAC
+
     @property
     def blockSize(self):
         """Return the size of block used by current symmetric cipher (R/O)"""

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -21,7 +21,7 @@ import socket
 from itertools import chain
 from .utils.compat import formatExceptionTrace
 from .tlsrecordlayer import TLSRecordLayer
-from .session import Session
+from .session import Session, Ticket
 from .constants import *
 from .utils.cryptomath import derive_secret, getRandomBytes, HKDF_expand_label
 from .utils.dns_utils import is_valid_hostname
@@ -575,10 +575,10 @@ class TLSConnection(TLSRecordLayer):
         #If the server elected to resume the session, it is handled here.
         for result in self._clientResume(session, serverHello,
                         clientHello.random,
-                        settings.cipherImplementations,
                         nextProto, settings):
             if result in (0,1): yield result
             else: break
+
         if result == "resumed_and_finished":
             self._handshakeDone(resumed=True)
             self._serverRandom = serverHello.random
@@ -666,7 +666,8 @@ class TLSConnection(TLSRecordLayer):
                             extendedMasterSecret=self.extendedMasterSecret,
                             appProto=alpnProto,
                             # NOTE it must be a reference not a copy
-                            tickets=self.tickets)
+                            tickets=self.tickets,
+                            tls_1_0_tickets=self.tls_1_0_tickets)
         self._handshakeDone(resumed=False)
         self._serverRandom = serverHello.random
         self._clientRandom = clientHello.random
@@ -785,6 +786,27 @@ class TLSConnection(TLSRecordLayer):
         if settings.record_size_limit:
             extensions.append(RecordSizeLimitExtension().create(
                 settings.record_size_limit))
+
+        # If SessionTicket support is enabled and we have a valid ticket, we
+        # send it in an attempt to resume the session, if SessionTicket support
+        # is enabled but we don't have a valid ticket, we send an empty ext
+        # to indicate support for the feaure
+        if session and session.tls_1_0_tickets:
+            # first get rid of expired tickets
+            session.tls_1_0_tickets[:] = [
+                i for i in session.tls_1_0_tickets if i.valid()]
+            # then send first ticket
+            for cached_ticket in session.tls_1_0_tickets:
+                extensions.append(SessionTicketExtension().create(
+                    cached_ticket.ticket))
+                break
+            else:
+                # or just advertise that we support session resumption
+                extensions.append(SessionTicketExtension().create(
+                    bytearray(0)))
+        else:
+            extensions.append(SessionTicketExtension().create(
+                bytearray(0)))
 
         # don't send empty list of extensions or extensions in SSLv3
         if not extensions or settings.maxVersion == (3, 0):
@@ -1596,11 +1618,12 @@ class TLSConnection(TLSRecordLayer):
                 return bytearray(nextProtos[0])
         return None
  
-    def _clientResume(self, session, serverHello, clientRandom, 
-                      cipherImplementations, nextProto, settings):
-        #If the server agrees to resume
-        if session and session.sessionID and \
-            serverHello.session_id == session.sessionID:
+    def _clientResume(self, session, serverHello, clientRandom,
+                      nextProto, settings):
+
+        if session and ((session.sessionID and \
+            serverHello.session_id == session.sessionID) or
+            session.tls_1_0_tickets):
 
             if serverHello.cipher_suite != session.cipherSuite:
                 for result in self._sendError(\
@@ -1612,7 +1635,7 @@ class TLSConnection(TLSRecordLayer):
             self._calcPendingStates(session.cipherSuite,
                                     session.masterSecret,
                                     clientRandom, serverHello.random,
-                                    cipherImplementations)
+                                    settings.cipherImplementations)
 
             #Exchange ChangeCipherSpec and Finished messages
             for result in self._getFinished(session.masterSecret,
@@ -1828,22 +1851,11 @@ class TLSConnection(TLSRecordLayer):
     def _clientFinished(self, premasterSecret, clientRandom, serverRandom,
                         cipherSuite, cipherImplementations, nextProto,
                         settings):
-        if self.extendedMasterSecret:
-            cvhh = self._certificate_verify_handshake_hash
-            # in case of session resumption, or when the handshake doesn't
-            # use the certificate authentication, the hashes are the same
-            if not cvhh:
-                cvhh = self._handshake_hash
-            masterSecret = calc_key(self.version, premasterSecret,
-                                    cipherSuite, b"extended master secret",
-                                    handshake_hashes=cvhh,
-                                    output_length=48)
-        else:
-            masterSecret = calc_key(self.version, premasterSecret,
-                                    cipherSuite, b"master secret",
-                                    client_random=clientRandom,
-                                    server_random=serverRandom,
-                                    output_length=48)
+
+        masterSecret = self._calculate_master_secret(premasterSecret,
+                                                     cipherSuite,
+                                                     clientRandom,
+                                                     serverRandom)
         self._calcPendingStates(cipherSuite, masterSecret, 
                                 clientRandom, serverRandom, 
                                 cipherImplementations)
@@ -2275,6 +2287,16 @@ class TLSConnection(TLSRecordLayer):
             extensions.append(RecordSizeLimitExtension().create(
                 min(2**14, settings.record_size_limit)))
 
+        # If the client indicates that it supports resumption using
+        # session_ticket extension, we send a zero len extension to indicate
+        # that we are going to
+        # send a new ticket in a NewSessionTicket message
+        send_session_ticket = False
+        session_ticket = clientHello.getExtension(ExtensionType.session_ticket)
+        if session_ticket and len(session_ticket.ticket) == 0:
+            send_session_ticket = True
+            extensions.append(SessionTicketExtension().create(
+                bytearray(0)))
 
         # don't send empty list of extensions
         if not extensions:
@@ -2377,17 +2399,8 @@ class TLSConnection(TLSRecordLayer):
 
         else:
             assert(False)
-                        
-        # Exchange Finished messages      
-        for result in self._serverFinished(premasterSecret, 
-                                clientHello.random, serverHello.random,
-                                cipherSuite, settings.cipherImplementations,
-                                nextProtos, settings):
-                if result in (0,1): yield result
-                else: break
-        masterSecret = result
 
-        #Create the session object
+        # Create the session object
         self.session = Session()
         if cipherSuite in CipherSuite.certAllSuites or \
                 cipherSuite in CipherSuite.ecdheEcdsaSuites:
@@ -2400,15 +2413,28 @@ class TLSConnection(TLSRecordLayer):
             srpUsername = clientHello.srp_username.decode("utf-8")
         if clientHello.server_name:
             serverName = clientHello.server_name.decode("utf-8")
-        self.session.create(masterSecret, serverHello.session_id, cipherSuite,
+
+        # We'll update the session master secret once it is calculated
+        # in _serverFinished
+        self.session.create(b"", serverHello.session_id, cipherSuite,
                             srpUsername, clientCertChain, serverCertChain,
                             tackExt, (serverHello.tackExt is not None),
                             serverName,
-                            encryptThenMAC=self._recordLayer.encryptThenMAC,
+                            encryptThenMAC=
+                            self._recordLayer._get_pending_state_etm(),
                             extendedMasterSecret=self.extendedMasterSecret,
                             appProto=selectedALPN,
                             # NOTE it must be a reference, not a copy!
                             tickets=self.tickets)
+
+        # Exchange Finished messages
+        for result in self._serverFinished(premasterSecret,
+                                clientHello.random, serverHello.random,
+                                cipherSuite, settings.cipherImplementations,
+                                nextProtos, settings, send_session_ticket,
+                                clientCertChain):
+                if result in (0,1): yield result
+                else: break
 
         #Add the session object to the session cache
         if sessionCache and sessionID:
@@ -2483,15 +2509,27 @@ class TLSConnection(TLSRecordLayer):
         if not settings.ticketKeys:
             return
 
-        for _ in range(settings.ticket_count):
+        if self.version < (3, 4):
+            secret = self.session.masterSecret
+        else:
+            secret = self.session.resumptionMasterSecret
+
+        # make sure we send at most one ticket in TLS 1.2 and earlier
+        for _ in range(settings.ticket_count if self.version > (3, 3) else
+                       int(bool(settings.ticket_count))):
             # prepare the ticket
             ticket = SessionTicketPayload()
-            ticket.create(self.session.resumptionMasterSecret,
+            ticket.create(secret,
                           self.version,
                           self.session.cipherSuite,
                           int(time.time()),
                           getRandomBytes(len(settings.ticketKeys[0])),
-                          client_cert_chain=self.session.clientCertChain)
+                          client_cert_chain=self.session.clientCertChain,
+                          encrypt_then_mac=
+                          self._recordLayer._get_pending_state_etm(),
+                          extended_master_secret=self.extendedMasterSecret,
+                          server_name=self.session.serverName.encode("utf-8")
+                          if self.session.serverName else bytearray())
 
             # encrypt the ticket
 
@@ -2515,12 +2553,18 @@ class TLSConnection(TLSRecordLayer):
             encrypted_ticket = cipher.seal(iv, ticket.write(), b'')
 
             # encapsulate the ticket and send to client
-            new_ticket = NewSessionTicket()
-            new_ticket.create(settings.ticketLifetime,
-                              getRandomNumber(1, 8**4),
-                              ticket.nonce,
-                              nonce + encrypted_ticket,
-                              [])
+            if self.version < (3, 4):
+                new_ticket = NewSessionTicket1_0()
+                new_ticket.create(settings.ticketLifetime,
+                                  nonce + encrypted_ticket)
+                self.tls_1_0_tickets.append(encrypted_ticket)
+            else:
+                new_ticket = NewSessionTicket()
+                new_ticket.create(settings.ticketLifetime,
+                                  getRandomNumber(1, 8**4),
+                                  ticket.nonce,
+                                  nonce + encrypted_ticket,
+                                  [])
             self._queue_message(new_ticket)
 
         # send tickets to client
@@ -2528,15 +2572,20 @@ class TLSConnection(TLSRecordLayer):
             for result in self._queue_flush():
                 yield result
 
-    def _tryDecrypt(self, settings, identity):
+    def _tryDecrypt(self, settings, identity=None, ticket=None):
         if not settings.ticketKeys:
             return None, None
 
-        if len(identity.identity) < 33:
-            # too small for an encrypted ticket
-            return None, None
+        if self.version < (3, 4):
+            assert ticket
+            nonce, encrypted_ticket = ticket[:32], ticket[32:]
+        else:
+            assert identity
+            if len(identity.identity) < 33:
+                # too small for an encrypted ticket
+                return None, None
+            nonce, encrypted_ticket = identity.identity[:32], identity.identity[32:]
 
-        nonce, encrypted_ticket = identity.identity[:32], identity.identity[32:]
         for user_key in settings.ticketKeys:
             key, iv = self._derive_key_iv(nonce, user_key, settings)
             if settings.ticketCipher in ("aes128gcm", "aes256gcm"):
@@ -2559,6 +2608,9 @@ class TLSConnection(TLSRecordLayer):
             except ValueError:
                 continue
 
+            if self.version < (3, 4):
+                return None, ticket
+
             prf = 'sha384' if ticket.cipher_suite \
                 in CipherSuite.sha384PrfSuites else 'sha256'
 
@@ -2572,7 +2624,7 @@ class TLSConnection(TLSRecordLayer):
 
             return ((identity.identity, psk, prf), ticket)
 
-        # no keys
+        # no working keys
         return None, None
 
     def _serverTLS13Handshake(self, settings, clientHello, cipherSuite,
@@ -2619,6 +2671,11 @@ class TLSConnection(TLSRecordLayer):
                         continue
                     match = [match]
 
+                # check if the ticket version matches
+                # but with PSK we don't have a ticket, but we still can have a
+                # binder value, so `match` will be non-null
+                if ticket and self.version != ticket.protocol_version:
+                    continue
                 # check if PSK can be used with selected cipher suite
                 psk_hash = match[0][2] if len(match[0]) > 2 else 'sha256'
                 if psk_hash != prf_name:
@@ -3012,6 +3069,31 @@ class TLSConnection(TLSRecordLayer):
             yield result
 
         yield "finished"
+
+    def _ticket_to_session(self, settings, ticket_ext):
+        if not ticket_ext.ticket:
+            return None
+        _, ticket = self._tryDecrypt(settings, ticket=ticket_ext.ticket)
+        if not ticket:
+            return None
+
+        if ticket.creation_time + settings.ticketLifetime < time.time():
+            return None
+
+        session = Session()
+        session.create(ticket.master_secret,
+                       b'',  # no session_id
+                       ticket.cipher_suite,
+                       '',  # not SRP
+                       ticket.client_cert_chain,
+                       None,  # no server cert chain
+                       None,  # no TACK
+                       False,  # no TACK
+                       serverName=ticket.server_name.decode("utf-8") if
+                       ticket.server_name else "",
+                       encryptThenMAC=ticket.encrypt_then_mac,
+                       extendedMasterSecret=ticket.extended_master_secret)
+        return session
 
     def _serverGetClientHello(self, settings, private_key, cert_chain,
                               verifierDB,
@@ -3456,14 +3538,31 @@ class TLSConnection(TLSRecordLayer):
                                                     minVersion=version,
                                                     maxVersion=version)
 
-        #If resumption was requested and we have a session cache...
-        if clientHello.session_id and sessionCache:
+        ticket_ext = clientHello.getExtension(ExtensionType.session_ticket)
+
+        # If resumption was requested and we have a session cache...
+        if (clientHello.session_id and sessionCache) or (
+                ticket_ext and ticket_ext.ticket):
             session = None
 
             # Check if the session there is good enough and consistent with
             # new Client Hello
             try:
-                session = sessionCache[clientHello.session_id]
+                if ticket_ext:
+                    session = self._ticket_to_session(settings, ticket_ext)
+                    # client MAY send a random session_id to easily tell
+                    # if the session is resumed, for that server has to
+                    # echo the session_ID back
+                    if session and clientHello.session_id:
+                        session.sessionID = clientHello.session_id
+                if not session and \
+                        (not ticket_ext or ticket_ext and not ticket_ext.ticket)\
+                        and sessionCache and clientHello.session_id:
+                    # Session ID resumption is allowed only if the client
+                    # didn't send a ticket
+                    session = sessionCache[clientHello.session_id]
+                if not session:
+                    raise KeyError()
                 if not session.resumable:
                     raise AssertionError()
                 # Check if we are willing to use that old cipher still
@@ -3521,9 +3620,9 @@ class TLSConnection(TLSRecordLayer):
                 extensions = []
                 if session.encryptThenMAC:
                     self._recordLayer.encryptThenMAC = True
-                    mte = TLSExtension().create(ExtensionType.encrypt_then_mac,
+                    etm = TLSExtension().create(ExtensionType.encrypt_then_mac,
                                                 bytearray(0))
-                    extensions.append(mte)
+                    extensions.append(etm)
                 if session.extendedMasterSecret:
                     ems = TLSExtension().create(ExtensionType.
                                                 extended_master_secret,
@@ -4300,26 +4399,16 @@ class TLSConnection(TLSRecordLayer):
         yield premasterSecret
 
 
-    def _serverFinished(self,  premasterSecret, clientRandom, serverRandom,
+    def _serverFinished(self, premasterSecret, clientRandom, serverRandom,
                         cipherSuite, cipherImplementations, nextProtos,
-                        settings):
-        if self.extendedMasterSecret:
-            cvhh = self._certificate_verify_handshake_hash
-            # in case of resumption or lack of certificate authentication,
-            # the CVHH won't be initialised, but then it would also be equal
-            # to regular handshake hash
-            if not cvhh:
-                cvhh = self._handshake_hash
-            masterSecret = calc_key(self.version, premasterSecret,
-                                    cipherSuite, b"extended master secret",
-                                    handshake_hashes=cvhh,
-                                    output_length=48)
-        else:
-            masterSecret = calc_key(self.version, premasterSecret,
-                                    cipherSuite, b"master secret",
-                                    client_random=clientRandom,
-                                    server_random=serverRandom,
-                                    output_length=48)
+                        settings, send_session_ticket=False,
+                        client_cert_chain=None):
+
+        masterSecret = self._calculate_master_secret(premasterSecret,
+                                                     cipherSuite,
+                                                     clientRandom,
+                                                     serverRandom)
+        self.session.masterSecret = masterSecret
 
         #Calculate pending connection states
         self._calcPendingStates(cipherSuite, masterSecret, 
@@ -4333,19 +4422,21 @@ class TLSConnection(TLSRecordLayer):
             yield result
 
         for result in self._sendFinished(masterSecret, cipherSuite,
-                settings=settings):
+                                         settings=settings,
+                                         send_session_ticket=send_session_ticket,
+                                         client_cert_chain=client_cert_chain):
             yield result
-        
-        yield masterSecret        
-
 
     #*********************************************************
     # Shared Handshake Functions
     #*********************************************************
 
-
     def _sendFinished(self, masterSecret, cipherSuite=None, nextProto=None,
-            settings=None):
+            settings=None, send_session_ticket=False, client_cert_chain=None):
+        if send_session_ticket:
+            for result in self._serverSendTickets(settings):
+                yield result
+
         # send the CCS and Finished in single TCP packet
         self.sock.buffer_writes = True
         #Send ChangeCipherSpec
@@ -4388,16 +4479,46 @@ class TLSConnection(TLSRecordLayer):
 
     def _getFinished(self, masterSecret, cipherSuite=None,
                      expect_next_protocol=False, nextProto=None):
-        #Get and check ChangeCipherSpec
-        for result in self._getMsg(ContentType.change_cipher_spec):
+
+        expect_ccs_message = True
+        # If we use SessionTicket resumption on client side, there are multiple
+        # situations where the server has the option to send new ticket
+        for result in self._getMsg(
+                (ContentType.handshake, ContentType.change_cipher_spec),
+                HandshakeType.new_session_ticket):
             if result in (0,1):
                 yield result
-        changeCipherSpec = result
+            else: break
 
-        if changeCipherSpec.type != 1:
-            for result in self._sendError(AlertDescription.illegal_parameter,
-                                         "ChangeCipherSpec type incorrect"):
-                yield result
+        if isinstance(result, NewSessionTicket1_0):
+            session_ticket = result
+            # If we receive new ticket we clear the old ones
+            del self.tls_1_0_tickets[:]
+            self.tls_1_0_tickets.append(Ticket(session_ticket.ticket,
+                                        session_ticket.ticket_lifetime,
+                                        masterSecret, cipherSuite))
+
+        else:
+            assert isinstance(result, ChangeCipherSpec)
+            expect_ccs_message = False
+
+            changeCipherSpec = result
+            if changeCipherSpec.type != 1:
+                for result in self._sendError(
+                        AlertDescription.illegal_parameter,
+                        "ChangeCipherSpec type incorrect"):
+                    yield result
+
+        if expect_ccs_message:
+            for result in self._getMsg(ContentType.change_cipher_spec):
+                if result in (0,1):
+                    yield result
+            changeCipherSpec = result
+
+            if changeCipherSpec.type != 1:
+                for result in self._sendError(AlertDescription.illegal_parameter,
+                                             "ChangeCipherSpec type incorrect"):
+                    yield result
 
         #Switch to pending read state
         self._changeReadState()
@@ -4468,6 +4589,27 @@ class TLSConnection(TLSRecordLayer):
         except:
             self._shutdown(False)
             raise
+
+    def _calculate_master_secret(self, premaster_secret, cipher_suite,
+                                 client_random, server_random):
+        if self.extendedMasterSecret:
+            cvhh = self._certificate_verify_handshake_hash
+            # in case of resumption or lack of certificate authentication,
+            # the CVHH won't be initialised, but then it would also be equal
+            # to regular handshake hash
+            if not cvhh:
+                cvhh = self._handshake_hash
+            secret = calc_key(self.version, premaster_secret,
+                              cipher_suite, b"extended master secret",
+                              handshake_hashes=cvhh,
+                              output_length=48)
+        else:
+            secret = calc_key(self.version, premaster_secret,
+                              cipher_suite, b"master secret",
+                              client_random=client_random,
+                              server_random=server_random,
+                              output_length=48)
+        return secret
 
     @staticmethod
     def _pickServerKeyExchangeSig(settings, clientHello, certList=None,

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -170,6 +170,8 @@ class TLSRecordLayer(object):
 
         # NewSessionTickets received from server
         self.tickets = []
+        # TLS 1.2 and earlier tickets received from server
+        self.tls_1_0_tickets = []
 
         # Indicator for heartbeat extension mode, if we can receive
         # heartbeat requests
@@ -1242,7 +1244,10 @@ class TLSRecordLayer(object):
                 elif subType == HandshakeType.encrypted_extensions:
                     yield EncryptedExtensions().parse(p)
                 elif subType == HandshakeType.new_session_ticket:
-                    yield NewSessionTicket().parse(p)
+                    if self.version < (3, 4):
+                        yield NewSessionTicket1_0().parse(p)
+                    else:
+                        yield NewSessionTicket().parse(p)
                 elif subType == HandshakeType.key_update:
                     yield KeyUpdate().parse(p)
                 else:

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -26,7 +26,8 @@ from tlslite.extensions import TLSExtension, SNIExtension, NPNExtension,\
         SrvSupportedVersionsExtension, SignatureAlgorithmsCertExtension, \
         PreSharedKeyExtension, PskIdentity, SrvPreSharedKeyExtension, \
         PskKeyExchangeModesExtension, CookieExtension, VarBytesExtension, \
-        HeartbeatExtension, IntExtension, RecordSizeLimitExtension
+        HeartbeatExtension, IntExtension, RecordSizeLimitExtension, \
+        SessionTicketExtension
 from tlslite.utils.codec import Parser, Writer
 from tlslite.constants import NameType, ExtensionType, GroupName,\
         ECPointFormat, HashAlgorithm, SignatureAlgorithm, \
@@ -2817,6 +2818,94 @@ class TestCookieExtension(unittest.TestCase):
     def test___repr___with_none(self):
         ext = CookieExtension()
         self.assertEqual(repr(ext), "CookieExtension(cookie=None)")
+
+
+class TestSessionTicketExtension(unittest.TestCase):
+    def test___init__(self):
+        ext = SessionTicketExtension()
+
+        self.assertIsNotNone(ext)
+        self.assertIsNone(ext.ticket)
+
+        self.assertEqual(ext.extType, 35)
+
+    def test_create(self):
+        ticket = mock.Mock()
+        ext = SessionTicketExtension().create(ticket)
+
+        self.assertIsInstance(ext, SessionTicketExtension)
+        self.assertIs(ext.ticket, ticket)
+
+    def test_write(self):
+        ticket = b"\x7b\x16\xa8\xd3\xac\xa8\xb9\x4f\x4f\x3e\xd1\x24\x21\xd0\x9c\xa7" \
+                 b"\x68\x20\xd3\x49\xbc\x53\x85\xfa\x84\x94\x44\x2a\x13\x9f\x36\xbd" \
+                 b"\x27\xda\x74\xad\x90\xb1\xf9\x4d\x51\x2c\x90\x83\x32\x57\xc7\x7d" \
+                 b"\x79\xcb\xba\x5e\xff\x12\x31\x7f\xf7\x20\x6d\x95\xac\xd3\x00\x15" \
+                 b"\x00\x40\xfc\x8a\x7b\x99\x02\x53\xa1\xdd\x2a\x46\x2a\xcc\x34\x23" \
+                 b"\x10\x48\xb8\x31\xed\xc5\x96\x83\xb8\x7a\xef\x8b\x1b\x60\x55\x4b" \
+                 b"\x0b\x42\x70\x69\x2f\x80\x84\xb5\x9f\x00\xfe\x91\x67\x4a\x58\xee" \
+                 b"\xc6\xf6\xe5\x87\x39\x6e\xd4\x40\x1a\x82\xc7\x62\x35\xa1\x2d\x5a" \
+                 b"\x15\x98"
+
+        ext = SessionTicketExtension().create(ticket)
+
+        self.assertEqual(bytearray(
+            b"\x00\x23" +         # ext type
+            b"\x00\x82" +         # ext length
+            ticket), ext.write()) # ticket
+
+    def test_parse(self):
+        ext = TLSExtension()
+
+        ticket = b"\x7b\x16\xa8\xd3\xac\xa8\xb9\x4f\x4f\x3e\xd1\x24\x21\xd0\x9c\xa7" \
+                 b"\x68\x20\xd3\x49\xbc\x53\x85\xfa\x84\x94\x44\x2a\x13\x9f\x36\xbd" \
+                 b"\x27\xda\x74\xad\x90\xb1\xf9\x4d\x51\x2c\x90\x83\x32\x57\xc7\x7d" \
+                 b"\x79\xcb\xba\x5e\xff\x12\x31\x7f\xf7\x20\x6d\x95\xac\xd3\x00\x15" \
+                 b"\x00\x40\xfc\x8a\x7b\x99\x02\x53\xa1\xdd\x2a\x46\x2a\xcc\x34\x23" \
+                 b"\x10\x48\xb8\x31\xed\xc5\x96\x83\xb8\x7a\xef\x8b\x1b\x60\x55\x4b" \
+                 b"\x0b\x42\x70\x69\x2f\x80\x84\xb5\x9f\x00\xfe\x91\x67\x4a\x58\xee" \
+                 b"\xc6\xf6\xe5\x87\x39\x6e\xd4\x40\x1a\x82\xc7\x62\x35\xa1\x2d\x5a" \
+                 b"\x15\x98"
+
+        parser = Parser(bytearray(
+            b"\x00\x23" + # ext type
+            b"\x00\x82" + # ext length
+            ticket))      # ticket
+
+        ext = ext.parse(parser)
+        self.assertIsInstance(ext, SessionTicketExtension)
+        self.assertEqual(ext.ticket, ticket)
+
+    def test_write_empty(self):
+        ticket = bytearray(0)
+
+        ext = SessionTicketExtension().create(ticket)
+
+        self.assertEqual(bytearray(
+            b"\x00\x23" +         # ext type
+            b"\x00\x00" +         # ext length
+            ticket), ext.write()) # ticket
+
+    def test_parse_empty(self):
+        ext = TLSExtension()
+
+        ticket = bytearray(0)
+
+        parser = Parser(bytearray(
+            b"\x00\x23" + # ext type
+            b"\x00\x00" + # ext length
+            ticket))      # ticket
+
+        ext = ext.parse(parser)
+        self.assertIsInstance(ext, SessionTicketExtension)
+        self.assertEqual(ext.ticket, ticket)
+
+    def test___repr__(self):
+        ext = SessionTicketExtension().create(bytearray(b'\xab\xcd'))
+
+        self.assertEqual(
+            str(ext),
+            "SessionTicketExtension(ticket=bytearray(b'\\xab\\xcd'))")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This enables both client and server side to resume session using session tickets defined in RFC5077.
I have tested this against openssl and gnutls, both client and server side in tls1.2, tls1.1 and tls1.0 and it seems to be working.
To enable it on client side all you need to is initialize an empty list for connection.session_ticket_cache where the tickets received from server are held.
Example:
```
session_cache = []
connection.session_ticket_cache = session_cache
```
To enable it on server side you need to generate the encryption keys that are held in settings.session_ticket_keys.
Example:
```
 settings.session_ticket_keys = {}
 settings.session_ticket_keys["key_name"] = getRandomBytes(16)
 settings.session_ticket_keys["aes_key"] = getRandomBytes(16)
 settings.session_ticket_keys["hmac_key"] = getRandomBytes(32)
```
This fixes #60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/437)
<!-- Reviewable:end -->
