### PR TITLE
use github-actions service name in coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.name }}
           COVERALLS_PARALLEL: true
-          COVERALLS_SERVICE_NAME: git hub actions
+          COVERALLS_SERVICE_NAME: github-actions
         run: coveralls
       - name: Publish coverage to Codeclimate
         if: ${{ contains(matrix.opt-deps, 'codeclimate') }}
@@ -336,7 +336,7 @@ jobs:
       - name: Finished
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_SERVICE_NAME: git hub actions
+          COVERALLS_SERVICE_NAME: github-actions
         run: |
           pip install --upgrade coveralls
           coveralls --service=github --finish


### PR DESCRIPTION
see what happens for a second build on a branch if we use github-actions service name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/452)
<!-- Reviewable:end -->
