### PR TITLE
Unify reports with py2 and py3 coverage in coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,14 +329,16 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Finished
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_SERVICE_NAME: git hub actions
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          pip install --upgrade coveralls
-          coveralls --service=github --finish
+          if [[ "${{ github.event.pull_request }}" ]]; then
+            PR_NUM=${GITHUB_REF#refs/pull/}
+            PR_NUM=${PR_NUM%/merge}
+            BUILD_NUM=${GITHUB_SHA}-PR-${PR_NUM}
+          else
+            BUILD_NUM=${GITHUB_SHA}
+          fi
+          curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=${BUILD_NUM}&payload[status]=done"

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 hypothesis
-coveralls
+coveralls==1.11.1
 pylint
 diff_cover
 pytest>=4.6.5


### PR DESCRIPTION
older pythons correctly compare the the branch to master and report the change in coverage, but not the new versions, see what happens if we try old coveralls on new pythons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/453)
<!-- Reviewable:end -->
