### PR TITLE
use new coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,10 +311,9 @@ jobs:
       - name: Publish coverage to Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.name }}
           COVERALLS_PARALLEL: true
-          COVERALLS_SERVICE_NAME: git hub actions
+          COVERALLS_SERVICE_NAME: github
         run: coveralls
       - name: Publish coverage to Codeclimate
         if: ${{ contains(matrix.opt-deps, 'codeclimate') }}
@@ -328,20 +327,14 @@ jobs:
     name: Indicate completion to coveralls.io
     needs: test
     runs-on: ubuntu-latest
+    container: python:3-slim
     steps:
-      - name: Finished
+      - name: Install coveralls
+        run: |
+          pip3 install --upgrade coveralls
+      - name: Send "finished" signal to coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
         run: |
-          echo "GITHUB_SHA:" $GITHUB_SHA
-          echo "GITHUB_REF:" $GITHUB_REF
-          if [[ "${{ github.event.pull_request }}" ]]; then
-            PR_NUM=${GITHUB_REF#refs/pull/}
-            PR_NUM=${PR_NUM%/merge}
-            BUILD_NUM=${GITHUB_SHA}-PR-${PR_NUM}
-          else
-            BUILD_NUM=${GITHUB_SHA}
-          fi
-          echo "BUILD_NUM:" $BUILD_NUM
-          curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=${BUILD_NUM}&payload[status]=done"
+          coveralls --finish

--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -5,7 +5,7 @@ cffi<1.14
 unittest2
 coverage
 hypothesis<3
-coveralls<1.3.0
+git+https://github.com/tomato42/coveralls-python.git@add-py26#egg=coveralls
 pylint
 diff_cover
 pycparser<2.19

--- a/build-requirements-3.3.txt
+++ b/build-requirements-3.3.txt
@@ -2,7 +2,7 @@ six>=1.10.0
 enum34
 coverage<5.0
 hypothesis<3.44
-coveralls
+git+https://github.com/tomato42/coveralls-python.git@add-py26#egg=coveralls
 pylint
 diff_cover<2.5.0
 typed-ast<1.3.0

--- a/build-requirements-3.4.txt
+++ b/build-requirements-3.4.txt
@@ -1,8 +1,7 @@
-unittest2
 coverage
 hypothesis
 git+https://github.com/tomato42/coveralls-python.git@add-py26#egg=coveralls
 pylint
-mock
-diff_cover<2.5.0
+diff_cover
 pytest>=4.6.5
+pluggy>=0.7

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 hypothesis
-coveralls==1.11.1
+coveralls
 pylint
 diff_cover
 pytest>=4.6.5


### PR DESCRIPTION
the curl trick to finish the run with merge doesn't work
(it does with pull_request though, go figure!), the problem is that
if we use new coveralls, it uses different build IDs so a new coveralls
can't finish a parallel run submission from old coveralls

use a fork on older pythons so that the IDs remain consistent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/458)
<!-- Reviewable:end -->
