### PR TITLE
fix error messages for deprecated methods

### DIFF
--- a/tlslite/mathtls.py
+++ b/tlslite/mathtls.py
@@ -735,7 +735,7 @@ def PRF_SSL(secret, seed, length):
             index += 1
     return bytes
 
-@deprecated_method("Please use calcKey method instead.")
+@deprecated_method("Please use calc_key function instead.")
 def calcExtendedMasterSecret(version, cipherSuite, premasterSecret,
                              handshakeHashes):
     """Derive Extended Master Secret from premaster and handshake msgs"""
@@ -759,7 +759,7 @@ def calcExtendedMasterSecret(version, cipherSuite, premasterSecret,
     return masterSecret
 
 
-@deprecated_method("Please use calcKey method instead.")
+@deprecated_method("Please use calc_key function instead.")
 def calcMasterSecret(version, cipherSuite, premasterSecret, clientRandom,
                      serverRandom):
     """Derive Master Secret from premaster secret and random values"""
@@ -784,7 +784,7 @@ def calcMasterSecret(version, cipherSuite, premasterSecret, clientRandom,
         raise AssertionError()
     return masterSecret
 
-@deprecated_method("Please use calcKey method instead.")
+@deprecated_method("Please use calc_key function instead.")
 def calcFinished(version, masterSecret, cipherSuite, handshakeHashes,
                  isClient):
     """Calculate the Handshake protocol Finished value


### PR DESCRIPTION
the function name is calc_key, not calcKey, and it's a function, not
a method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/463)
<!-- Reviewable:end -->
