### PR TITLE
RSA fixes

### DIFF
--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -387,16 +387,15 @@ def getRandomPrime(bits, display=False):
     #29 % 30 and keep them there
     low = ((2 ** (bits-1)) * 3) // 2
     high = 2 ** bits - 30
-    p = getRandomNumber(low, high)
-    p += 29 - (p % 30)
-    while 1:
-        if display: print(".", end=' ')
-        p += 30
-        if p >= high:
-            p = getRandomNumber(low, high)
-            p += 29 - (p % 30)
-        if isPrime(p, display=display):
-            return p
+    while True:
+        if display:
+            print(".", end=' ')
+        cand_p = getRandomNumber(low, high)
+        # make odd
+        if cand_p % 2 == 0:
+            cand_p += 1
+        if isPrime(cand_p, display=display):
+            return cand_p
 
 
 #Unused at the moment...


### PR DESCRIPTION
fix  #465

* the prime generation is bad/biased
* there is no retry in case the t isn't coprime with 65537

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/466)
<!-- Reviewable:end -->
