### PR TITLE
handle both missing parameters and NULL parameters for RSA-PSS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,9 +337,15 @@ jobs:
       - name: Lint the code
         # pylint doesn't work on 2.6: https://bitbucket.org/logilab/pylint/issue/390/py26-compatiblity-broken
         if: ${{ matrix.python-version != '2.6' }}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
+          opt=""
+          if ! [[ $PYTHON_VERSION == 2.6 || $PYTHON_VERSION == 2.7 || $PYTHON_VERSION == 3.3 || $PYTHON_VERSION == 3.4 || $PYTHON_VERSION == 3.5 ]]; then
+              opt="--compare-branch origin/master"
+          fi
           pylint --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" tlslite > pylint_report.txt || :
-          diff-quality --violations=pylint --fail-under=90 pylint_report.txt
+          diff-quality $opt --violations=pylint --fail-under=90 pylint_report.txt
       - name: Verify that intermediate commits are testable
         if: ${{ github.event.pull_request }}
         env:

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -345,6 +345,14 @@ class AlgorithmOID(TLSEnum):
             SignatureScheme.rsa_pss_rsae_sha384
     oid[bytes(a2b_hex('300b0609608648016503040203'))] = \
             SignatureScheme.rsa_pss_rsae_sha512
+    # for RSA-PSS an AlgorithmIdentifier with and without NULL parameters
+    # is valid. See RFC 4055 Section 2.1
+    oid[bytes(a2b_hex('300d06096086480165030402010500'))] = \
+            SignatureScheme.rsa_pss_rsae_sha256
+    oid[bytes(a2b_hex('300d06096086480165030402020500'))] = \
+            SignatureScheme.rsa_pss_rsae_sha384
+    oid[bytes(a2b_hex('300d06096086480165030402030500'))] = \
+            SignatureScheme.rsa_pss_rsae_sha512
     oid[bytes(a2b_hex('06072A8648CE380403'))] = \
             SignatureScheme.dsa_sha1
     oid[bytes(a2b_hex('0609608648016503040301'))] = \


### PR DESCRIPTION
 RFC 4055 Section 2.1 allows both no parameters for AlgorithmIdentifier and NULL parameters, so accept both.

fixes #470

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/471)
<!-- Reviewable:end -->
