### PR TITLE
Draft: add support for RFC 8879 TLS Certificate Compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,31 +144,31 @@ jobs:
             python-version: '3.10'
             opt-deps: ['gmpy2']
           # finally test with multiple dependencies installed at the same time
-          - name: py2.7 with m2crypto, pycrypto, gmpy, and gmpy2
+          - name: py2.7 with m2crypto, pycrypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: 2.7
-            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2']
-          - name: py3.6 with m2crypto, pycrypto, gmpy, and gmpy2
+            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2', 'brotli', 'zstd']
+          - name: py3.6 with m2crypto, pycrypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: 3.6
-            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2']
-          - name: py3.7 with m2crypto, pycrypto, gmpy, and gmpy2
+            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2', 'brotli', 'zstd']
+          - name: py3.7 with m2crypto, pycrypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: 3.7
-            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2']
-          - name: py3.8 with m2crypto, gmpy, and gmpy2
+            opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2', 'brotli', 'zstd']
+          - name: py3.8 with m2crypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: 3.8
-            opt-deps: ['m2crypto', 'gmpy', 'gmpy2']
-          - name: py3.9 with m2crypto, gmpy, and gmpy2
+            opt-deps: ['m2crypto', 'gmpy', 'gmpy2', 'brotli', 'zstd']
+          - name: py3.9 with m2crypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: 3.9
-            opt-deps: ['m2crypto', 'gmpy', 'gmpy2']
-          - name: py3.10 with m2crypto, gmpy, and gmpy2
+            opt-deps: ['m2crypto', 'gmpy', 'gmpy2', 'brotli', 'zstd']
+          - name: py3.10 with m2crypto, gmpy, gmpy2, brotli and zstd
             os: ubuntu-latest
             python-version: '3.10'
             # coverage to codeclimate can be submitted just once
-            opt-deps: ['m2crypto', 'gmpy', 'gmpy2', 'codeclimate']
+            opt-deps: ['m2crypto', 'gmpy', 'gmpy2', 'brotli', 'zstd', 'codeclimate']
     steps:
       - uses: actions/checkout@v2
         if: ${{ !matrix.container }}
@@ -267,6 +267,12 @@ jobs:
       - name: Install gmpy2
         if: ${{ contains(matrix.opt-deps, 'gmpy2') }}
         run: pip install gmpy2
+      - name: Install brotli
+        if: ${{ contains(matrix.opt-deps, 'brotli') }}
+        run: pip install Brotli
+      - name: Install zstd
+        if: ${{ contains(matrix.opt-deps, 'zstd') }}
+        run: pip install zstd
       - name: Install build dependencies (2.6)
         if: ${{ matrix.python-version == '2.6' }}
         run: |

--- a/tlslite/api.py
+++ b/tlslite/api.py
@@ -24,6 +24,7 @@ from .integration.xmlrpcserver import TLSXMLRPCRequestHandler, \
                                       TLSXMLRPCServer, \
                                       MultiPathTLSXMLRPCServer
 
+from .utils.compression import brotliLoaded, zstdLoaded
 from .utils.cryptomath import m2cryptoLoaded, gmpyLoaded, \
                              pycryptoLoaded, prngName, GMPY2_LOADED
 from .utils.keyfactory import generateRSAKey, parsePEMKey, \

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -87,6 +87,12 @@ class ClientCertificateType(TLSEnum):
     ecdsa_fixed_ecdh = 66  # RFC 8422
 
 
+class CertificateCompressionAlgorithm(TLSEnum):  # RFC 8879
+    zlib = 1
+    brotli = 2
+    zstd = 3
+
+
 class SSL2HandshakeType(TLSEnum):
     """SSL2 Handshake Protocol message types."""
 
@@ -128,6 +134,7 @@ class HandshakeType(TLSEnum):
     finished = 20
     certificate_status = 22
     key_update = 24  # TLS 1.3
+    compressed_certificate = 25  # RFC 8879
     next_protocol = 67
     message_hash = 254  # TLS 1.3
 
@@ -167,6 +174,7 @@ class ExtensionType(TLSEnum):
     client_hello_padding = 21  # RFC 7685
     encrypt_then_mac = 22  # RFC 7366
     extended_master_secret = 23  # RFC 7627
+    compress_certificate = 27  # RFC 8879
     record_size_limit = 28  # RFC 8449
     extended_random = 40  # draft-rescorla-tls-extended-random-02
     pre_shared_key = 41  # TLS 1.3

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -283,3 +283,9 @@ class UnknownRSAType(EncryptionError):
     """Unknown RSA algorithm type passed"""
 
     pass
+
+
+class DependencyMissing(BaseTLSException):
+    """Optional TLSLite dependency is missing"""
+
+    pass

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -66,6 +66,14 @@ class Session(object):
     :ivar resumptionMasterSecret: master secret used for session resumption in
         TLS 1.3
 
+    :vartype serverCertCompressionAlgorithm: string
+    :ivar serverCertCompressionAlgorithm: certificate compression algorithm
+        used for the server certificate, TLS 1.3
+
+    :vartype clientCertCompressionAlgorithm: string
+    :ivar clientCertCompressionAlgorithm: certificate compression algorithm
+        used for the server certificate, TLS 1.3
+
     :vartype tickets: list
     :ivar tickets: list of tickets received from the server
     """
@@ -88,6 +96,8 @@ class Session(object):
         self.sr_app_secret = bytearray(0)
         self.exporterMasterSecret = bytearray(0)
         self.resumptionMasterSecret = bytearray(0)
+        self.serverCertCompressionAlgorithm = None
+        self.clientCertCompressionAlgorithm = None
         self.tickets = None
 
     def create(self, masterSecret, sessionID, cipherSuite,
@@ -96,7 +106,10 @@ class Session(object):
                encryptThenMAC=False, extendedMasterSecret=False,
                appProto=bytearray(0), cl_app_secret=bytearray(0),
                sr_app_secret=bytearray(0), exporterMasterSecret=bytearray(0),
-               resumptionMasterSecret=bytearray(0), tickets=None):
+               resumptionMasterSecret=bytearray(0),
+               serverCertCompressionAlgorithm=None,
+               clientCertCompressionAlgorithm=None,
+               tickets=None):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite
@@ -114,6 +127,8 @@ class Session(object):
         self.sr_app_secret = sr_app_secret
         self.exporterMasterSecret = exporterMasterSecret
         self.resumptionMasterSecret = resumptionMasterSecret
+        self.serverCertCompressionAlgorithm = serverCertCompressionAlgorithm
+        self.clientCertCompressionAlgorithm = clientCertCompressionAlgorithm
         # NOTE we need a reference copy not a copy of object here!
         self.tickets = tickets
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -1198,6 +1198,9 @@ class TLSRecordLayer(object):
                     yield ServerHello().parse(p)
                 elif subType == HandshakeType.certificate:
                     yield Certificate(constructorType, self.version).parse(p)
+                elif subType == HandshakeType.compressed_certificate:
+                    yield CompressedCertificate(constructorType, self.version)\
+                            .parse(p)
                 elif subType == HandshakeType.certificate_request:
                     yield CertificateRequest(self.version).parse(p)
                 elif subType == HandshakeType.certificate_verify:

--- a/tlslite/utils/compression.py
+++ b/tlslite/utils/compression.py
@@ -1,0 +1,16 @@
+# Author: Alexander Sosedkin
+# See the LICENSE file for legal information regarding use of this file.
+
+import zlib  # pylint: disable=unused-import
+
+try:
+    import brotli  # pylint: disable=unused-import
+    brotliLoaded = True
+except ImportError:
+    brotliLoaded = False
+
+try:
+    import zstd  # pylint: disable=unused-import
+    zstdLoaded = True
+except ImportError:
+    zstdLoaded = False

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -13,6 +13,7 @@ except ImportError:
     import unittest.mock as mock
 
 from tlslite.handshakesettings import HandshakeSettings, Keypair, VirtualHost
+from tlslite.utils.compression import brotliLoaded, zstdLoaded
 
 class TestHandshakeSettings(unittest.TestCase):
     def test___init__(self):
@@ -84,6 +85,41 @@ class TestHandshakeSettings(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             hs.validate()
+
+    def test_certCompressionAlgorithms_with_known_name(self):
+        hs = HandshakeSettings()
+        hs.certCompressionAlgorithms = ["zlib"]
+
+        newHs = hs.validate()
+
+        self.assertEqual(["zlib"], newHs.certCompressionAlgorithms)
+
+    def test_certCompressionAlgorithms_with_unknown_name(self):
+        hs = HandshakeSettings()
+        hs.certCompressionAlgorithms = ["nonex", "zlib"]
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_certCompressionAlgorithms_empty(self):
+        hs = HandshakeSettings()
+        hs.certCompressionAlgorithms = []
+
+        newHs = hs.validate()
+
+        self.assertEqual([], newHs.certCompressionAlgorithms)
+
+    def test_certCompressionAlgorithms_filtering_out(self):
+        hs = HandshakeSettings()
+        hs.certCompressionAlgorithms = ["zlib", "brotli", "zstd"]
+
+        newHs = hs.validate()
+
+        self.assertTrue("zlib" in newHs.certCompressionAlgorithms)
+        self.assertTrue(("brotli" in newHs.certCompressionAlgorithms) ==
+                        brotliLoaded)
+        self.assertTrue(("zstd" in newHs.certCompressionAlgorithms) ==
+                        zstdLoaded)
 
     def test_certificateTypes_empty(self):
         hs = HandshakeSettings()


### PR DESCRIPTION
I'm sketching up RFC 8879 TLS Certificate Compression support. My intent is to use it with tlsfuzzer to test gnutls' implementation of it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/484)
<!-- Reviewable:end -->
