### PR TITLE
Add support for compress_certificate extension

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -128,6 +128,7 @@ class HandshakeType(TLSEnum):
     finished = 20
     certificate_status = 22
     key_update = 24  # TLS 1.3
+    compressed_certificate = 25  # TLS 1.3, RFC 8879
     next_protocol = 67
     message_hash = 254  # TLS 1.3
 
@@ -167,6 +168,7 @@ class ExtensionType(TLSEnum):
     client_hello_padding = 21  # RFC 7685
     encrypt_then_mac = 22  # RFC 7366
     extended_master_secret = 23  # RFC 7627
+    compress_certificate = 27  # RFC 8879
     record_size_limit = 28  # RFC 8449
     extended_random = 40  # draft-rescorla-tls-extended-random-02
     pre_shared_key = 41  # TLS 1.3
@@ -180,6 +182,15 @@ class ExtensionType(TLSEnum):
     supports_npn = 13172
     tack = 0xF300
     renegotiation_info = 0xff01  # RFC 5746
+
+
+class CompressionAlgorithms(TLSEnum):
+    """
+    Compression algorithms used in CompressCertificate msg and extension (TLSv1.3+)
+    """
+    zlib = 1
+    brotli = 2
+    zstd = 3
 
 
 class HashAlgorithm(TLSEnum):

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -12,7 +12,7 @@ from .utils.codec import Writer, Parser, DecodeError
 from .constants import NameType, ExtensionType, CertificateStatusType, \
         SignatureAlgorithm, HashAlgorithm, SignatureScheme, \
         PskKeyExchangeMode, CertificateType, GroupName, ECPointFormat, \
-        HeartbeatMode
+        HeartbeatMode, CompressionAlgorithms
 from .errors import TLSInternalError
 
 
@@ -2100,6 +2100,41 @@ class RecordSizeLimitExtension(IntExtension):
             2, 'record_size_limit', ExtensionType.record_size_limit)
 
 
+class CompressCertificateExtension(VarListExtension):
+
+    def __init__(self):
+        """
+        Create instance of class
+        """
+
+        super(CompressCertificateExtension, self).__init__(
+            2, 1, 'advertised_algorithms',
+            ExtensionType.compress_certificate,
+            CompressionAlgorithms)
+
+    def parse(self, parser):
+        """
+        Parse the extension from on the wire format
+
+        :type parser: Parser
+        :param parser: Parser object with raw encoded data
+        """
+        # generic code allows empty, this ext does not
+        if not parser.getRemainingLength():
+            raise DecodeError("Empty payload in extension")
+        return super(CompressCertificateExtension, self).parse(parser)
+
+    def create(self, advertised_algorithms):
+        """
+        Create instance of compress_certificate extension for writing
+
+        :type advertised_algorithms: iterable(int)
+        :param advertised_algorithms: an iterable of integers denoting which algorithms the peer
+                                      supports for compression
+        """
+        return super(CompressCertificateExtension, self).create(advertised_algorithms)
+
+
 TLSExtension._universalExtensions = \
     {
         ExtensionType.server_name: SNIExtension,
@@ -2121,7 +2156,9 @@ TLSExtension._universalExtensions = \
         ExtensionType.pre_shared_key: PreSharedKeyExtension,
         ExtensionType.psk_key_exchange_modes: PskKeyExchangeModesExtension,
         ExtensionType.cookie: CookieExtension,
-        ExtensionType.record_size_limit: RecordSizeLimitExtension}
+        ExtensionType.record_size_limit: RecordSizeLimitExtension,
+        ExtensionType.compress_certificate: CompressCertificateExtension
+    }
 
 TLSExtension._serverExtensions = \
     {

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -7,8 +7,8 @@
 
 """Class for setting handshake parameters."""
 
-from .constants import CertificateType
-from .utils import cryptomath
+from .constants import CertificateType, CompressionAlgorithms
+from .utils import cryptomath, compression
 from .utils import cipherfactory
 from .utils.compat import ecdsaAllCurves, int_types
 
@@ -348,6 +348,14 @@ class HandshakeSettings(object):
     :vartype keyExchangeNames: list
     :ivar keyExchangeNames: Enabled key exchange types for the connection,
         influences selected cipher suites.
+
+    :vartype use_certificate_compression: bool
+    :ivar use_certificate_compression: Whether to advertise support for
+        compress_certificate extension.
+
+    :vartype certificate_compression_algorithms: tuple(int)
+    :ivar certificate_compression_algorithms: A tuple of integers that signal
+        which algorithms to support for certificate compression
     """
 
     def _init_key_settings(self):
@@ -379,6 +387,9 @@ class HandshakeSettings(object):
         self.usePaddingExtension = True
         self.useExtendedMasterSecret = True
         self.requireExtendedMasterSecret = False
+        # certificate compression extensions
+        self.use_certificate_compression = False
+        self.certificate_compression_algorithms = compression.DEFAULT
         # PSKs
         self.pskConfigs = []
         self.psk_modes = list(PSK_MODES)
@@ -575,6 +586,33 @@ class HandshakeSettings(object):
                              "useExtendedMasterSecret")
 
     @staticmethod
+    def _sanityCheckCertCompressExtension(other):
+        """
+        Check if compress_certificate extension settings are valid
+        """
+
+        if other.maxVersion < (3, 4) and other.use_certificate_compression:
+            # Problem: certificate compression can only be sent on TLS 1.3. However, submitting it as True on lower
+            # TLS settings doesn't really change much since the setting will just be ignored. So, should we raise an
+            # exception or just a present a simple warning? Do nothing for now (needs to be changed).
+            pass
+
+        if not other.certificate_compression_algorithms:
+            raise ValueError("no algorithm was supplied to be advertised for certificate compression")
+
+        for algo in other.certificate_compression_algorithms:
+            try:
+                is_supported = compression.is_installed(algo)
+            except KeyError:
+                raise ValueError("unknown algorithm ({}) provided for certificate compression".format(algo))
+            if not is_supported:
+                # is_supported can only be False if algorithm is brotli or zstd (zlib is part of standard module)
+                algo_library = "brotli" if algo == CompressionAlgorithms.brotli else "zstandard"
+                raise ValueError("Preference for {} compression was provided, but dependency was not found. You can "
+                                 "install it by doing:\n"
+                                 "    pip install {}".format(CompressionAlgorithms.toRepr(algo), algo_library))
+
+    @staticmethod
     def _sanityCheckExtensions(other):
         """Check if set extension settings are sane"""
         if other.useEncryptThenMAC not in (True, False):
@@ -586,6 +624,9 @@ class HandshakeSettings(object):
         if other.use_heartbeat_extension not in (True, False):
             raise ValueError("use_heartbeat_extension must be True or False")
 
+        if other.use_certificate_compression not in (True, False):
+            raise ValueError("use_certificate_compression must be True or False")
+
         if other.heartbeat_response_callback and not other.use_heartbeat_extension:
             raise ValueError("heartbeat_response_callback requires "
                              "use_heartbeat_extension")
@@ -595,6 +636,7 @@ class HandshakeSettings(object):
             raise ValueError("record_size_limit cannot exceed 2**14+1 bytes")
 
         HandshakeSettings._sanityCheckEMSExtension(other)
+        HandshakeSettings._sanityCheckCertCompressExtension(other)
 
     @staticmethod
     def _not_allowed_len(values, sieve):
@@ -662,6 +704,9 @@ class HandshakeSettings(object):
         other.sendFallbackSCSV = self.sendFallbackSCSV
         other.useEncryptThenMAC = self.useEncryptThenMAC
         other.usePaddingExtension = self.usePaddingExtension
+        # cert compress
+        other.use_certificate_compression = self.use_certificate_compression
+        other.certificate_compression_algorithms = self.certificate_compression_algorithms
         # session tickets
         other.padding_cb = self.padding_cb
         other.ticketKeys = self.ticketKeys

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -412,7 +412,6 @@ class TLSConnection(TLSRecordLayer):
         for result in self._handshakeWrapperAsync(handshaker, checker):
             yield result
 
-
     def _handshakeClientAsyncHelper(self, srpParams, certParams, anonParams,
                                session, settings, serverName, nextProtos,
                                reqTack, alpn):
@@ -785,6 +784,10 @@ class TLSConnection(TLSRecordLayer):
         if settings.record_size_limit:
             extensions.append(RecordSizeLimitExtension().create(
                 settings.record_size_limit))
+
+        if settings.use_certificate_compression:
+            extensions.append(CompressCertificateExtension().create(
+                settings.certificate_compression_algorithms))
 
         # don't send empty list of extensions or extensions in SSLv3
         if not extensions or settings.maxVersion == (3, 0):
@@ -1275,10 +1278,18 @@ class TLSConnection(TLSRecordLayer):
         # if we negotiated PSK then Certificate is not sent
         certificate_request = None
         certificate = None
+        compress_cert_ext = clientHello.getExtension(ExtensionType.compress_certificate)
+
         if not sr_psk:
+            expected_types = (HandshakeType.certificate_request,
+                              HandshakeType.certificate)
+
+            # Add compressed_certificate message to expected types if its extension was advertised
+            if compress_cert_ext:
+                expected_types += (HandshakeType.compressed_certificate, )
+
             for result in self._getMsg(ContentType.handshake,
-                                       (HandshakeType.certificate_request,
-                                        HandshakeType.certificate),
+                                       expected_types,
                                        CertificateType.x509):
                 if result in (0, 1):
                     yield result
@@ -1286,18 +1297,57 @@ class TLSConnection(TLSRecordLayer):
                     break
 
             if isinstance(result, CertificateRequest):
+                # we got CertificateRequest, so now we'll get Certificate (or CompressedCertificate)
                 certificate_request = result
+                expected_types = (HandshakeType.certificate, )
 
-                # we got CertificateRequest so now we'll get Certificate
+                # Add compressed_certificate message to expected types if its extension was advertised
+                if compress_cert_ext:
+                    expected_types += (HandshakeType.compressed_certificate,)
+
                 for result in self._getMsg(ContentType.handshake,
-                                           HandshakeType.certificate,
+                                           expected_types,
                                            CertificateType.x509):
                     if result in (0, 1):
                         yield result
                     else:
                         break
 
-            certificate = result
+            # If we got a CompressedCertificate msg, perform quick validation checks and get decompressed msg
+            if isinstance(result, CompressedCertificate):
+                compress_cert_msg = result
+
+                if compress_cert_msg.chosen_algorithm not in compress_cert_ext.advertised_algorithms:
+                    for result in self._sendError(
+                            AlertDescription.illegal_parameter,
+                            "Server compressed certificate with an algorithm we did not advertise"):
+                        yield result
+
+                uncompressed_cert = compress_cert_msg.decompress()
+                if compress_cert_msg.uncompressed_length != len(uncompressed_cert):
+                    for result in self._sendError(
+                            AlertDescription.bad_certificate,
+                            "Server sent an uncompressed certificate length that does not match with the actual "
+                            "uncompressed certificate length"):
+                        yield result
+
+                version = serverHello.getExtension(ExtensionType.supported_versions).version
+                p = Parser(uncompressed_cert)
+
+                # Attempt to parse the certificate with proper error handling as it would have been in _getMsg
+                try:
+                    certificate = Certificate(CertificateType.x509, version).parse(p)
+                except BadCertificateError as e:
+                    for result in self._sendError(AlertDescription.bad_certificate,
+                                                  formatExceptionTrace(e)):
+                        yield result
+                except SyntaxError as e:
+                    for result in self._sendError(AlertDescription.decode_error,
+                                                  formatExceptionTrace(e)):
+                        yield result
+            else:
+                certificate = result
+
             assert isinstance(certificate, Certificate)
 
             srv_cert_verify_hh = self._handshake_hash.copy()
@@ -1408,8 +1458,21 @@ class TLSConnection(TLSRecordLayer):
                             "Client certificate is of wrong type"):
                         yield result
 
-            client_certificate.create(clientCertChain)
             # we need to send the message even if we don't have a certificate
+            client_certificate.create(clientCertChain)
+
+            # if server supports compressed certificates, we check if we can send a compressed certificate instead
+            verify_compress_cert_ext = certificate_request.getExtension(ExtensionType.compress_certificate)
+            hello_compress_cert_ext = clientHello.getExtension(ExtensionType.compress_certificate)
+
+            if verify_compress_cert_ext and hello_compress_cert_ext:
+                # If we can send a compressed certificate then we loop over server supported algorithms to find a
+                # common one. We use the first match to compress certificate if there is one, otherwise we send a normal
+                # Certificate message instead
+                for requested_algo in verify_compress_cert_ext.advertised_algorithms:
+                    if requested_algo in hello_compress_cert_ext.advertised_algorithms:
+                        client_certificate = CompressedCertificate().create(requested_algo, client_certificate)
+
             for result in self._sendMsg(client_certificate):
                 yield result
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -1198,6 +1198,8 @@ class TLSRecordLayer(object):
                     yield ServerHello().parse(p)
                 elif subType == HandshakeType.certificate:
                     yield Certificate(constructorType, self.version).parse(p)
+                elif subType == HandshakeType.compressed_certificate:
+                    yield CompressedCertificate().parse(p)
                 elif subType == HandshakeType.certificate_request:
                     yield CertificateRequest(self.version).parse(p)
                 elif subType == HandshakeType.certificate_verify:

--- a/tlslite/utils/compression.py
+++ b/tlslite/utils/compression.py
@@ -1,0 +1,105 @@
+import zlib
+
+from tlslite.constants import CompressionAlgorithms
+from tlslite.utils.codec import BadCertificateError
+
+_is_installed = {CompressionAlgorithms.zlib: True,
+                 CompressionAlgorithms.brotli: False,
+                 CompressionAlgorithms.zstd: False}
+
+try:
+    import brotli
+except ModuleNotFoundError:
+    pass
+else:
+    _is_installed[CompressionAlgorithms.brotli] = True
+
+try:
+    import zstandard
+except ModuleNotFoundError:
+    pass
+else:
+    _is_installed[CompressionAlgorithms.zstd] = True
+    _zstd_compress = zstandard.ZstdCompressor()
+    _zstd_decompress = zstandard.ZstdDecompressor()
+
+
+def is_installed(algorithm):
+    """
+    Check if given algorithm's library is installed or not.
+
+    :type algorithm: int
+    :param algorithm: the algorithm to check for
+
+    raise KeyError: if provided algorithm integer is unknown
+    """
+    return _is_installed[algorithm]
+
+
+def decompress(chosen_algorithm, data):
+    """
+    Decompress given certificate data with a particular algorithm
+
+    :type chosen_algorithm: int
+    :param chosen_algorithm: the algorithm to use
+
+    :param data: compressed data to decompress
+
+    :raise BadCertificateError: if decompression failed
+    :raise ValueError: if chosen_algorithm is unknown
+    """
+    if chosen_algorithm == CompressionAlgorithms.zlib:
+        try:
+            return zlib.decompress(data)
+        except zlib.error as exc:
+            raise BadCertificateError(exc)
+    elif chosen_algorithm == CompressionAlgorithms.zstd:
+        try:
+            return _zstd_decompress.decompress(data)
+        except Exception as exc:
+            raise BadCertificateError(exc)
+    elif chosen_algorithm == CompressionAlgorithms.brotli:
+        try:
+            return brotli.decompress(data)
+        except brotli.error as exc:
+            raise BadCertificateError(exc)
+    else:
+        raise ValueError("Unknown algorithm ({}) provided".format(chosen_algorithm))
+
+
+def compress(chosen_algorithm, data):
+    """
+    Compress given certificate data with a particular algorithm
+
+    :type chosen_algorithm: int
+    :param chosen_algorithm: the algorithm to use
+
+    :param data: data to compress
+
+    :raise BadCertificateError: if compression failed
+    :raise ValueError: if chosen_algorithm is unknown
+    """
+
+    if chosen_algorithm == CompressionAlgorithms.zlib:
+        try:
+            return zlib.compress(data)
+        except zlib.error as exc:
+            raise BadCertificateError(exc)
+    elif chosen_algorithm == CompressionAlgorithms.zstd:
+        try:
+            return _zstd_compress.compress(data)
+        except Exception as exc:
+            raise BadCertificateError(exc)
+    elif chosen_algorithm == CompressionAlgorithms.brotli:
+        try:
+            return brotli.compress(data)
+        except brotli.error as exc:
+            raise BadCertificateError(exc)
+    else:
+        raise ValueError("Unknown algorithm ({}) provided".format(chosen_algorithm))
+
+
+ALL = tuple(_is_installed.keys())  # All supported algorithms
+DEFAULT = (1, )                    # Default algorithms to use if user has no preference
+
+__all__ = ["compress", "decompress", "is_installed", "ALL", "DEFAULT"]

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -13,6 +13,7 @@ except ImportError:
     import unittest.mock as mock
 
 from tlslite.handshakesettings import HandshakeSettings, Keypair, VirtualHost
+from tlslite.utils import compression
 
 class TestHandshakeSettings(unittest.TestCase):
     def test___init__(self):
@@ -212,6 +213,47 @@ class TestHandshakeSettings(unittest.TestCase):
         hs = HandshakeSettings()
         hs.useExtendedMasterSecret = False
         hs.requireExtendedMasterSecret = True
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_use_compress_cert_with_wrong_value(self):
+        hs = HandshakeSettings()
+        hs.use_certificate_compression = 3
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_cert_compress_algorithms_with_empty_value(self):
+        hs = HandshakeSettings()
+        hs.use_certificate_compression = True
+        hs.certificate_compression_algorithms = ()
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_cert_compress_algorithms_with_invalid_value(self):
+        hs = HandshakeSettings()
+        hs.use_certificate_compression = True
+        hs.certificate_compression_algorithms = (0, 1, 2)
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    @unittest.skipIf(compression.is_installed(2), "Skipping because brotli is already installed")
+    def test_cert_compress_algorithms_without_brotli(self):
+        hs = HandshakeSettings()
+        hs.use_certificate_compression = True
+        hs.certificate_compression_algorithms = (2, )
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    @unittest.skipIf(compression.is_installed(3), "Skipping because zstandard is already installed")
+    def test_cert_compress_algorithms_without_zstd(self):
+        hs = HandshakeSettings()
+        hs.use_certificate_compression = True
+        hs.certificate_compression_algorithms = (3, )
 
         with self.assertRaises(ValueError):
             hs.validate()


### PR DESCRIPTION
This implements Certificate Compression extension and msg (rfc 8879). Unfortunately, I saw that there was already an open pull request #484 addressing the same a little too late. To avoid repetition, I skimmed through the discussion and implemented relevant feedback. The two main differences in the implementation of the above pull request and this one is that:

1. We keep class `Certificate` and class `CompressedCertificate` separate (instead of the latter being a wrapper around the first)
2. We handle validation checks in the calling code, not during message parsing

This keeps integration with tlslite-ng relatively simple. To help with the review, here's what the pull request is meant to add:

- Support for sending `compress_certificate` extension as a client
- Support for parsing `CompressedCertificate` msg as a client
- Support for parsing `compress_certificate` extension in `CertificateRequest` msg
- Ability to send a `CompressedCertificate` msg if the server advertises support for compression

The server equivalent of the above points are not present yet but can be trivially added after initial review.  One area that needs attention is the code for `CompressedCertificate` class, specifically the `.create()` and `decompress()` methods (I have added relevant comments explaining the problem). The rfc was a bit vague to me on what exact bytes the encoded compressed certificate msg will have (whether it's type + length + encoded message after decompression or just length + encoded msg), so some changes might be needed there but they should be minimal. For this reason, I have not added tests for `CompressedCertificate` msg

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/491)
<!-- Reviewable:end -->
