### PR TITLE
fix CI with python2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             python-version: '3.10'
             opt-deps: ['m2crypto']
           - name: py2.7 with pycrypto
-            os: ubuntu-latest
+            os: ubuntu-20.04
             python-version: 2.7
             opt-deps: ['pycrypto']
           - name: py3.6 with pycrypto
@@ -86,7 +86,7 @@ jobs:
             # it doesn't break pycrypto code
             opt-deps: ['pycryptodome']
           - name: py2.7 with gmpy
-            os: ubuntu-latest
+            os: ubuntu-20.04
             python-version: 2.7
             opt-deps: ['gmpy']
           - name: py3.6 with gmpy
@@ -110,7 +110,7 @@ jobs:
             python-version: '3.10'
             opt-deps: ['gmpy']
           - name: py2.7 with gmpy2
-            os: ubuntu-latest
+            os: ubuntu-20.04
             python-version: 2.7
             opt-deps: ['gmpy2']
           - name: py3.6 with gmpy2
@@ -135,7 +135,7 @@ jobs:
             opt-deps: ['gmpy2']
           # finally test with multiple dependencies installed at the same time
           - name: py2.7 with m2crypto, pycrypto, gmpy, and gmpy2
-            os: ubuntu-latest
+            os: ubuntu-20.04
             python-version: 2.7
             opt-deps: ['m2crypto', 'pycrypto', 'gmpy', 'gmpy2']
           - name: py3.6 with m2crypto, pycrypto, gmpy, and gmpy2
@@ -207,10 +207,20 @@ jobs:
         run: git fetch origin master:refs/remotes/origin/master
       - name: Set up Python ${{ matrix.python-version }}
         # we use containers to use the native python version from them
-        if: ${{ !matrix.container }}
+        if: ${{ !matrix.container && matrix.python-version != '2.7' }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Ensure python 2.7
+        if: matrix.python-version == '2.7'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python2.7 python2.7-dev python-pip-whl
+          sudo ln -sf python2.7 /usr/bin/python
+          export PYTHONPATH=`echo /usr/share/python-wheels/pip-*py2*.whl`
+          sudo --preserve-env=PYTHONPATH python -m pip install --upgrade pip setuptools wheel
+          sudo chown -R $USER /usr/local/lib/python2.7
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Display installed python package versions


### PR DESCRIPTION
github actions people decided that python2.7 is "persona non grata" so use the native python2.7 from the standard container that they do support...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/493)
<!-- Reviewable:end -->
