### PR TITLE
detect malformed CCS messages

### DIFF
--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1898,6 +1898,8 @@ class ChangeCipherSpec(object):
         p.setLengthCheck(1)
         self.type = p.get(1)
         p.stopLengthCheck()
+        if p.getRemainingLength():
+            raise DecodeError("Multi-byte CCS message")
         return self
 
     def write(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -3278,6 +3278,14 @@ class TestChangeCipherSpec(unittest.TestCase):
         self.assertIsInstance(ccs, ChangeCipherSpec)
         self.assertEqual(ccs.type, 1)
 
+    def test_parse_wrong_size(self):
+        parser = Parser(bytearray(b'\x01\x01'))
+
+        ccs = ChangeCipherSpec()
+
+        with self.assertRaises(SyntaxError):
+            ccs.parse(parser)
+
 
 class TestNextProtocol(unittest.TestCase):
     def test___init__(self):


### PR DESCRIPTION
Fix handling of multi-byte CCS messages, fixes #464

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/495)
<!-- Reviewable:end -->
