### PR TITLE
check handshake messages for interleaving and alignment in TLS 1.3

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -117,8 +117,9 @@ class HandshakeType(TLSEnum):
     client_hello = 1
     server_hello = 2
     new_session_ticket = 4
-    hello_retry_request = 6  # draft version of TLS 1.3
-    encrypted_extensions = 8
+    end_of_early_data = 5  # TLS 1.3
+    hello_retry_request = 6  # TLS 1.3
+    encrypted_extensions = 8  # TLS 1.3
     certificate = 11
     server_key_exchange = 12
     certificate_request = 13

--- a/tlslite/defragmenter.py
+++ b/tlslite/defragmenter.py
@@ -126,3 +126,7 @@ class Defragmenter(object):
         """Remove all data from buffers"""
         for key in self.buffers.keys():
             self.buffers[key] = bytearray(0)
+
+    def is_empty(self):
+        """Return True if all buffers are empty."""
+        return all(not i for i in self.buffers.values())


### PR DESCRIPTION
Handshake messages in general MUST NOT be interleaved with other record types, and messages that cause key changes MUST be aligned with a record boundary.

Fixes #342

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/496)
<!-- Reviewable:end -->
