### PR TITLE
Send the first server flight in single record

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2746,6 +2746,7 @@ class TLSConnection(TLSRecordLayer):
                            clientHello.session_id,
                            cipherSuite, extensions=sh_extensions)
 
+        self.sock.buffer_writes = True
         msgs = []
         msgs.append(serverHello)
         if not self._ccs_sent and clientHello.session_id:
@@ -2895,6 +2896,9 @@ class TLSConnection(TLSRecordLayer):
         self._queue_message(finished)
         for result in self._queue_flush():
             yield result
+
+        self.sock.flush()
+        self.sock.buffer_writes = False
 
         self._changeReadState()
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -902,14 +902,11 @@ class TLSRecordLayer(object):
 
     def _sendMsgs(self, msgs):
         # send messages together in a single TCP write
-        self.sock.buffer_writes = True
         randomizeFirstBlock = True
         for msg in msgs:
             for result in self._sendMsg(msg, randomizeFirstBlock):
                 yield result
             randomizeFirstBlock = True
-        self.sock.flush()
-        self.sock.buffer_writes = False
 
     def _sendMsg(self, msg, randomizeFirstBlock=True, update_hashes=True):
         """Fragment and send message through socket"""


### PR DESCRIPTION
As it's much more efficient to send messages in a single TCP packet, so do try to do that both for plaintext and encrypted messages in the handshake.