### PR TITLE
Basic maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             python-version: '3.11'
           - name: py3.12
             os: ubuntu-latest
-            python-version: '3.12.0-beta.4'
+            python-version: '3.12'
           - name: py2.6
             os: ubuntu-latest
             container: centos:6
@@ -148,6 +148,10 @@ jobs:
             os: ubuntu-latest
             python-version: '3.11'
             opt-deps: ['gmpy2']
+          - name: py3.12 with gmpy2
+            os: ubuntu-latest
+            python-version: '3.12'
+            opt-deps: ['gmpy2']
           # finally test with multiple dependencies installed at the same time
           - name: py2.7 with m2crypto, pycrypto, gmpy, and gmpy2
             os: ubuntu-20.04
@@ -177,6 +181,11 @@ jobs:
             os: ubuntu-latest
             python-version: '3.11'
             # gmpy doesn't build with 3.11
+            opt-deps: ['m2crypto', 'gmpy2']
+          - name: py3.12 with m2crypto, gmpy, and gmpy2
+            os: ubuntu-latest
+            python-version: '3.12'
+            # gmpy doesn't build with 3.12
             # coverage to codeclimate can be submitted just once
             opt-deps: ['m2crypto', 'gmpy2', 'codeclimate']
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,12 @@ jobs:
         if: ${{ contains(matrix.opt-deps, 'gmpy2') }}
         run: sudo apt-get install -y libmpfr-dev libmpc-dev
       - name: Install gmpy2
-        if: ${{ contains(matrix.opt-deps, 'gmpy2') }}
+        if: ${{ contains(matrix.opt-deps, 'gmpy2') && matrix.python-version != '3.12' }}
         run: pip install gmpy2
+      - name: Install gmpy2 on py3.12
+        if: ${{ contains(matrix.opt-deps, 'gmpy2') && matrix.python-version == '3.12' }}
+        # for py3.12 we need pre-release version: https://github.com/aleaxit/gmpy/issues/446
+        run: pip install --pre gmpy2
       - name: Install build dependencies (2.6)
         if: ${{ matrix.python-version == '2.6' }}
         run: |

--- a/tlslite/api.py
+++ b/tlslite/api.py
@@ -21,7 +21,7 @@ from .integration.tlssocketservermixin import TLSSocketServerMixIn
 try:
     from .integration.tlsasyncdispatchermixin import TLSAsyncDispatcherMixIn
 except ModuleNotFoundError:
-    # asyncore was removed in 3.12, I don't use use it, so don't know how
+    # asyncore was removed in 3.12, I don't use it, so don't know how
     # to fix it
     pass
 from .integration.pop3_tls import POP3_TLS

--- a/tlslite/utils/openssl_rsakey.py
+++ b/tlslite/utils/openssl_rsakey.py
@@ -29,7 +29,8 @@ def password_callback(v, prompt1='Enter private key passphrase:',
 
 
 if m2cryptoLoaded:
-    import M2Crypto
+    # pylint: disable=import-error
+    from M2Crypto.RSA import RSAError
 
     class OpenSSL_RSAKey(RSAKey):
         def __init__(self, n=0, e=0, key_type="rsa"):
@@ -84,7 +85,7 @@ if m2cryptoLoaded:
         def _call_m2crypto(self, method, param, err_msg):
             try:
                 return bytearray(method(self.rsa, bytes(param), m2.no_padding))
-            except M2Crypto.RSA.RSAError:
+            except RSAError:
                 raise ValueError(err_msg)
 
         def _raw_public_key_op_bytes(self, ciphertext):

--- a/unit_tests/test_tlslite_utils_keyfactory.py
+++ b/unit_tests/test_tlslite_utils_keyfactory.py
@@ -16,6 +16,7 @@ from tlslite.utils import cryptomath
 
 if cryptomath.m2cryptoLoaded:
     import M2Crypto
+    from M2Crypto.EVP import EVPError
 
 class TestParsePEMKey(unittest.TestCase):
 
@@ -173,8 +174,10 @@ class TestParsePEMKey(unittest.TestCase):
 
         # XXX doesn't handle files without newlines
         # old version of M2Crypto return a Null, in Python3 it raises exception
-        if M2Crypto.version_info >= (0, 28, 0):
-            exp = M2Crypto.EVP.EVPError
+        # M2Crypto 0.40.0 dropped `version_info` attribute
+        if not hasattr(M2Crypto, 'version_info') or \
+                M2Crypto.version_info >= (0, 28, 0):
+            exp = EVPError
         else:
             exp = SyntaxError
         with self.assertRaises(exp):


### PR DESCRIPTION
Test with release version of python 3.12, work with newer m2crypto versions, workaround gmpy2 and py3.12...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/508)
<!-- Reviewable:end -->
