### PR TITLE
Add signature_algorithms_cert extension to _serverTLS13Handshake

### DIFF
--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -396,6 +396,10 @@ class HandshakeSettings(object):
         # resumed connections (as tickets are single-use in TLS 1.3
         self.ticket_count = 2
         self.record_size_limit = 2**14 + 1  # TLS 1.3 includes content type
+        # data needed for the signature algorithms cert extension
+        self.more_sig_schemes_cert = []
+        self.ecdsaSigHashesCert = []
+        self.rsaSigHashesCert = []
 
     def __init__(self):
         """Initialise default values for settings."""
@@ -675,6 +679,10 @@ class HandshakeSettings(object):
         other.max_early_data = self.max_early_data
         other.ticket_count = self.ticket_count
         other.record_size_limit = self.record_size_limit
+        # signature algorithms cert
+        other.more_sig_schemes_cert = self.more_sig_schemes_cert
+        other.ecdsaSigHashesCert = self.ecdsaSigHashesCert
+        other.rsaSigHashesCert = self.rsaSigHashesCert
 
     @staticmethod
     def _remove_all_matches(values, needle):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2830,9 +2830,15 @@ class TLSConnection(TLSRecordLayer):
                 cr_settings.dsaSigHashes = []
                 valid_sig_algs = self._sigHashesToList(cr_settings)
                 assert valid_sig_algs
-
+                cr_settings.more_sig_schemes = cr_settings.more_sig_schemes_cert
+                cr_settings.ecdsaSigHashes = cr_settings.ecdsaSigHashesCert
+                cr_settings.rsaSigHashes = cr_settings.rsaSigHashesCert
+                valid_sig_algs_cert = self._sigHashesToList(cr_settings)
                 certificate_request = CertificateRequest(self.version)
                 certificate_request.create(context=ctx, sig_algs=valid_sig_algs)
+                if valid_sig_algs_cert:
+                    sig_algs_cert_ext = SignatureAlgorithmsCertExtension().create(valid_sig_algs_cert)
+                    certificate_request.addExtension(sig_algs_cert_ext)
                 self._queue_message(certificate_request)
 
             certificate = Certificate(CertificateType.x509, self.version)


### PR DESCRIPTION
At the moment the **_serverTLS13Handshake** function does not have a simple way to generate and send the `signature_algorithms_cert` extension. Since the extension is not generated by OpenSSL, tlslite-ng is the easiest way I found to create a webserver that sends this extension