### PR TITLE
make int_to_bytes and numberToByteArray encode 0 as b'\x00'

### DIFF
--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1738,7 +1738,10 @@ class ClientKeyExchange(HandshakeMsg):
             else:
                 raise AssertionError()
         elif self.cipherSuite in CipherSuite.dhAllSuites:
-            self.dh_Yc = bytesToNumber(parser.getVarBytes(2))
+            val = parser.getVarBytes(2)
+            if len(val) < 1:
+                raise DecodeError("DH key share too short")
+            self.dh_Yc = bytesToNumber(val)
         elif self.cipherSuite in CipherSuite.ecdhAllSuites:
             self.ecdh_Yc = parser.getVarBytes(1)
         else:

--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -106,7 +106,10 @@ if sys.version_info >= (3,0):
     def int_to_bytes(val, length=None, byteorder="big"):
         """Return number converted to bytes"""
         if length is None:
-            length = byte_length(val)
+            if val:
+                length = byte_length(val)
+            else:
+                length = 1
         # for gmpy we need to convert back to native int
         if type(val) != int:
             val = int(val)
@@ -206,7 +209,10 @@ else:
     def int_to_bytes(val, length=None, byteorder="big"):
         """Return number converted to bytes"""
         if length is None:
-            length = byte_length(val)
+            if val:
+                length = byte_length(val)
+            else:
+                length = 1
         if byteorder == "big":
             return bytearray((val >> i) & 0xff
                              for i in reversed(range(0, length*8, 8)))

--- a/unit_tests/test_tlslite_utils_cryptomath.py
+++ b/unit_tests/test_tlslite_utils_cryptomath.py
@@ -100,6 +100,12 @@ class TestNumberToBytesFunctions(unittest.TestCase):
         self.assertEqual(numberToByteArray(0x00000000000001),
                          bytearray(b'\x01'))
 
+    def test_numberToByteArray_zero_bigendian(self):
+        self.assertEqual(numberToByteArray(0, endian="big"), bytearray(b'\x00'))
+
+    def test_numberToByteArray_zero_littleendian(self):
+        self.assertEqual(numberToByteArray(0, endian="little"), bytearray(b'\x00'))
+
     def test_numberToByteArray_with_MSB_number(self):
         self.assertEqual(numberToByteArray(0xff),
                          bytearray(b'\xff'))


### PR DESCRIPTION
make int_to_bytes() and numberToByteArray() consistent with int().to_bytes() from python3, that means encoding zero as a single null byte, not as an empty byte string

also fix the bug hidden by it:
ClientKeyExchange: correctly detect too short key shares

the field for DH key shares is defined as
```
case explicit: opaque DH_Yc<1..2^16-1>;
```
so the share must be at least 1 byte long, update the code to abort if it is too short

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/527)
<!-- Reviewable:end -->
