### PR TITLE
add support for Brainpool curves in TLS 1.3 (RFC8734)

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -109,7 +109,7 @@ def printUsage(s=None):
     [-c CERT] [-k KEY] [-t TACK] [-v VERIFIERDB] [-d DIR] [-l LABEL] [-L LENGTH]
     [--reqcert] [--param DHFILE] [--psk PSK] [--psk-ident IDENTITY]
     [--psk-sha384] [--ssl3] [--max-ver VER] [--tickets COUNT] [--cipherlist]
-    [--request-pha] [--require-pha] [--echo]
+    [--request-pha] [--require-pha] [--echo] [--groups GROUPS]
     HOST:PORT
 
   client
@@ -137,6 +137,8 @@ def printUsage(s=None):
   --require-pha - abort connection if client didn't provide certificate in
                   post-handshake authentication
   --echo - function as an echo server
+  --groups - specify what key exchange groups should be supported
+  GROUPS - comma-separated list of enabled key exchange groups
   CERT, KEY - the file with key and certificates that will be used by client or
         server. The server can accept multiple pairs of `-c` and `-k` options
         to configure different certificates (like RSA and ECDSA)
@@ -197,6 +199,7 @@ def handleArgs(argv, argString, flagsList=[]):
     request_pha = False
     require_pha = False
     echo = False
+    groups = None
 
     for opt, arg in opts:
         if opt == "-k":
@@ -270,6 +273,8 @@ def handleArgs(argv, argString, flagsList=[]):
             tickets = int(arg)
         elif opt == "--cipherlist":
             ciphers.append(arg)
+        elif opt == "--groups":
+            groups = arg.split(',')
         elif opt == "--request-pha":
             request_pha = True
         elif opt == "--require-pha":
@@ -344,6 +349,8 @@ def handleArgs(argv, argString, flagsList=[]):
         retList.append(require_pha)
     if "echo" in flagsList:
         retList.append(echo)
+    if "groups=" in flagsList:
+        retList.append(groups)
     return retList
 
 
@@ -547,12 +554,13 @@ def serverCmd(argv):
     (address, privateKey, cert_chain, virtual_hosts, tacks, verifierDB,
             directory, reqCert,
             expLabel, expLength, dhparam, psk, psk_ident, psk_hash, ssl3,
-            max_ver, tickets, cipherlist, request_pha, require_pha, echo) = \
+            max_ver, tickets, cipherlist, request_pha, require_pha, echo,
+            groups) = \
         handleArgs(argv, "kctbvdlL",
                    ["reqcert", "param=", "psk=",
                     "psk-ident=", "psk-sha384", "ssl3", "max-ver=",
                     "tickets=", "cipherlist=", "request-pha", "require-pha",
-                    "echo"])
+                    "echo", "groups="])
 
 
     if (cert_chain and not privateKey) or (not cert_chain and privateKey):
@@ -599,6 +607,17 @@ def serverCmd(argv):
     if cipherlist:
         settings.cipherNames = [item for cipher in cipherlist
                                 for item in cipher.split(',')]
+    if groups:
+        dh_groups = []
+        ecc_groups = []
+        for item in groups:
+            if "ffdh" in item:
+                dh_groups.append(item)
+            else:
+                ecc_groups.append(item)
+        settings.dhGroups = dh_groups
+        settings.eccCurves = ecc_groups
+        settings.keyShares = []
 
     class MySimpleEchoHandler(BaseRequestHandler):
         def handle(self):

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -321,6 +321,14 @@ class SignatureScheme(TLSEnum):
         return hName
 
 
+# set of TLS 1.3 specific schemes for Brainpool curves
+TLS_1_3_BRAINPOOL_SIG_SCHEMES = set([
+    SignatureScheme.ecdsa_brainpoolP256r1tls13_sha256,
+    SignatureScheme.ecdsa_brainpoolP384r1tls13_sha384,
+    SignatureScheme.ecdsa_brainpoolP512r1tls13_sha512,
+])
+
+
 class AlgorithmOID(TLSEnum):
     """
     Algorithm OIDs as defined in rfc5758(ecdsa),

--- a/tlslite/utils/ecc.py
+++ b/tlslite/utils/ecc.py
@@ -15,7 +15,10 @@ def getCurveByName(curveName):
                 'secp256k1':ecdsa.SECP256k1,
                 'brainpoolP256r1': ecdsa.BRAINPOOLP256r1,
                 'brainpoolP384r1': ecdsa.BRAINPOOLP384r1,
-                'brainpoolP512r1': ecdsa.BRAINPOOLP512r1}
+                'brainpoolP512r1': ecdsa.BRAINPOOLP512r1,
+                'brainpoolP256r1tls13': ecdsa.BRAINPOOLP256r1,
+                'brainpoolP384r1tls13': ecdsa.BRAINPOOLP384r1,
+                'brainpoolP512r1tls13': ecdsa.BRAINPOOLP512r1}
     if ecdsaAllCurves:
         curveMap['secp224r1'] = ecdsa.NIST224p
         curveMap['secp192r1'] = ecdsa.NIST192p


### PR DESCRIPTION
Add support for Brainpool curves in TLS 1.3, both for ECDH and signing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/529)
<!-- Reviewable:end -->
