### PR TITLE
publish wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ COVERAGE3 := $(shell which coverage3 2>/dev/null)
 
 .PHONY : default
 default:
-	@echo To install tlslite run \"./setup.py install\" or \"make install\"
+	@echo To install tlslite run \"python -m pip install .\" or \"make install\"
 
 .PHONY: install
 install:
-	./setup.py install
+	python -m pip install .
 
 .PHONY : clean
 clean:
@@ -33,10 +33,12 @@ clean:
 
 .PHONY : docs
 docs:
+	python -m pip install -r docs/requirements.txt
 	$(MAKE) -C docs html
 
 dist: docs
-	./setup.py sdist
+	python -m pip install build
+	python -m build
 
 .PHONY : test
 test:


### PR DESCRIPTION
Direct invocation of setup.py [is deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)

It is desirable to publish wheels.  Else everyone who installs your package has to build the wheel themselves: which is slower, and might conceivably go wrong.  

Better for package maintainers to build their wheels once and for all rather than make everyone else do it, every time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/534)
<!-- Reviewable:end -->
