### PR TITLE
fail kyber_py import because of SyntaxError too

### DIFF
--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -244,5 +244,9 @@ try:
     del ML_KEM_1024
 except ImportError:
     ML_KEM_AVAILABLE = False
+except SyntaxError:
+    # trying to import it on older Python versions causes it to abort with
+    # SyntaxError not ImportError
+    ML_KEM_AVAILABLE = False
 else:
     ML_KEM_AVAILABLE = True


### PR DESCRIPTION
On Python 2 the import succeeds, but then it errors out with SyntaxError, handle that gracefully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/535)
<!-- Reviewable:end -->
