### PR TITLE
use the new calling convention for setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ COVERAGE3 := $(shell which coverage3 2>/dev/null)
 
 .PHONY : default
 default:
-	@echo To install tlslite run \"./setup.py install\" or \"make install\"
+	@echo To install tlslite run \"python -m pip install .\" or \"make install\"
 
 .PHONY: install
 install:
-	./setup.py install
+	python -m pip install .
 
 .PHONY : clean
 clean:
@@ -36,7 +36,7 @@ docs:
 	$(MAKE) -C docs html
 
 dist: docs
-	./setup.py sdist
+	python -m build
 
 .PHONY : test
 test:


### PR DESCRIPTION
build both the source distribution and a wheel

obsoletes #534

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/536)
<!-- Reviewable:end -->
