### PR TITLE
fix: point extension control only up to tls 1.2

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -3437,19 +3437,20 @@ class TLSConnection(TLSRecordLayer):
                 yield result
 
         # sanity check the ec point formats extension
-        ecExt = clientHello.getExtension(ExtensionType.ec_point_formats)
-        if ecExt:
-            if not ecExt.formats:
-                for result in self._sendError(
-                        AlertDescription.decode_error,
-                        "Empty ec_point_formats extension"):
-                    yield result
-            if ECPointFormat.uncompressed not in ecExt.formats:
-                for result in self._sendError(
-                        AlertDescription.illegal_parameter,
-                        "Client sent ec_point_formats extension "
-                        "without uncompressed format"):
-                    yield result
+        if real_version <= (3, 3):
+            ecExt = clientHello.getExtension(ExtensionType.ec_point_formats)
+            if ecExt:
+                if not ecExt.formats:
+                    for result in self._sendError(
+                            AlertDescription.decode_error,
+                            "Empty ec_point_formats extension"):
+                        yield result
+                if ECPointFormat.uncompressed not in ecExt.formats:
+                    for result in self._sendError(
+                            AlertDescription.illegal_parameter,
+                            "Client sent ec_point_formats extension "
+                            "without uncompressed format"):
+                        yield result
 
         # sanity check the TLS 1.3 extensions
         ver_ext = clientHello.getExtension(ExtensionType.supported_versions)


### PR DESCRIPTION
sanity check of the ec point formats extension of clientHello only up to tls 1.2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/538)
<!-- Reviewable:end -->
