### PR TITLE
don't negotiate legacy brainpool IDs in TLS 1.3

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -4014,7 +4014,10 @@ class TLSConnection(TLSRecordLayer):
                 share_ids = [i.group for i in share.client_shares]
                 acceptable_ids = [getattr(GroupName, i) for i in
                                   chain(settings.keyShares, settings.eccCurves,
-                                        settings.dhGroups)]
+                                        settings.dhGroups)
+                                  if i not in ("brainpoolP512r1",
+                                               "brainpoolP384r1",
+                                               "brainpoolP256r1")]
                 for selected_group in acceptable_ids:
                     if selected_group in share_ids:
                         cl_key_share = next(i for i in share.client_shares


### PR DESCRIPTION
Stop the server accepting the legacy TLS 1.2 Brainpool group IDs in TLS 1.3, allow only TLS 1.3 specific group IDs.

Test coverage: https://github.com/tlsfuzzer/tlsfuzzer/pull/983

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/539)
<!-- Reviewable:end -->
