### PR TITLE
code-climate is dead, remove it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,7 @@ jobs:
             os: ubuntu-latest
             python-version: '3.13'
             # gmpy doesn't build with 3.13
-            # coverage to codeclimate can be submitted just once
-            opt-deps: ['m2crypto', 'gmpy2', 'codeclimate', 'brotli', 'zstd', 'kyber_py']
+            opt-deps: ['m2crypto', 'gmpy2', 'brotli', 'zstd', 'kyber_py']
     steps:
       - uses: actions/checkout@v2
         if: ${{ !matrix.container }}
@@ -415,14 +414,6 @@ jobs:
         run: pip install -r requirements.txt
       - name: Display installed python package versions
         run: pip list
-      - name: Prepare Codeclimate environment
-        if: ${{ contains(matrix.opt-deps, 'codeclimate') }}
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
       - name: Run unit tests (2.7+)
         if: ${{ matrix.python-version != '2.6' }}
         run: coverage run --branch --source tlslite -m unittest discover
@@ -491,16 +482,6 @@ jobs:
           else
             coveralls
           fi
-      - name: Publish coverage to Codeclimate
-        if: ${{ contains(matrix.opt-deps, 'codeclimate') }}
-        env:
-          # yes, one could argue that making even a "write-only" token public is bad practice
-          # but it's practice that the codeclimate explicitly supports:
-          # https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret
-          CC_TEST_REPORTER_ID: 192c24c0112eddbedbb0570c7e0111858061be407451b285e27b5a43f70b99d8
-        run: |
-          coverage xml
-          ./cc-test-reporter after-build
 
   coveralls:
     name: Indicate completion to coveralls.io


### PR DESCRIPTION
Code climate is no more so remove it to stop CI from failing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/557)
<!-- Reviewable:end -->
