### PR TITLE
add support for tls_flags extension

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -182,6 +182,7 @@ class ExtensionType(TLSEnum):
     signature_algorithms_cert = 50  # TLS 1.3
     key_share = 51  # TLS 1.3
     delegated_credential = 34 # TLS 1.3, RFC 9345
+    tls_flags = 62  # draft-ietf-tls-tlsflags-17
     supports_npn = 13172
     tack = 0xF300
     renegotiation_info = 0xff01  # RFC 5746

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -9,6 +9,7 @@ and ServerHello messages.
 from __future__ import generators
 from collections import namedtuple
 from .utils.codec import Writer, Parser, DecodeError
+from .utils.compat import int_to_bytes
 from .constants import NameType, ExtensionType, CertificateStatusType, \
         SignatureAlgorithm, HashAlgorithm, SignatureScheme, \
         PskKeyExchangeMode, CertificateType, GroupName, ECPointFormat, \
@@ -2220,6 +2221,78 @@ class CompressedCertificateExtension(VarListExtension):
             CertificateCompressionAlgorithm)
 
 
+class TLSFlagsExtension(TLSExtension):
+    """
+    tls_flags extension from draft-ietf-tls-tlsflags.
+
+    Encodes payload-less extensions in a compact manner: an LSB bit-string.
+
+    :vartype flags: set of int
+    :ivar flags: a set of integers representing bit indices (0..2039)
+    """
+
+    def __init__(self):
+        """Create an instance of the tls_flags extension."""
+        super(TLSFlagsExtension, self).__init__(extType=
+                                                ExtensionType.tls_flags)
+        self.flags = set()
+
+    def __repr__(self):
+        """Return human readable representation of the extension."""
+        flags = ', '.join(str(f) for f in sorted(self.flags))
+        return "TLSFlagsExtension(flags={{{}}})".format(flags)
+
+    def create(self, flags):
+        """Set the tls_flags value in the extension."""
+        if not flags:
+            raise ValueError("tls_flags must have at least one flag set")
+        for flag in flags:
+            if not 0 <= flag <= 2039:
+                raise ValueError("tls_flags flag {} out of the 0..2039 range"
+                                 .format(flag))
+        self.flags = set(flags)
+        return self
+
+    @property
+    def extData(self):
+        """Serialise the payload of the extension."""
+        if not self.flags:
+            raise ValueError("tls_flags must have at least one flag set")
+        nbytes = max(self.flags) // 8 + 1
+        val = 0
+        for flag in self.flags:
+            val |= (1 << flag)
+        writer = Writer()
+        writer.add_var_bytes(int_to_bytes(val, nbytes, 'little'), 1)
+        return writer.bytes
+
+    def parse(self, parser):
+        """
+        Parse the extension from on the wire format.
+
+        :param Parser parser: data to be parsed
+
+        :rtype: TLSFlagsExtension
+
+        :raises DecodeError: when the payload of the extension is malformed
+        """
+        data = parser.getVarBytes(1)
+        if not data:
+            raise DecodeError("tls_flags payload cannot be empty")
+        if not any(b for b in data):
+            raise DecodeError("tls_flags must have at least one non-zero byte")
+        if not data[-1]:
+            raise DecodeError("tls_flags must not have trailing zeroes")
+        self.flags = set()
+        for i, byte in enumerate(data):
+            for bit in range(8):
+                if byte & (1 << bit):
+                    self.flags.add(i * 8 + bit)
+        if parser.getRemainingLength():
+            raise DecodeError("Extra data after extension payload")
+        return self
+
+
 TLSExtension._universalExtensions = {
     ExtensionType.server_name: SNIExtension,
     ExtensionType.status_request: StatusRequestExtension,
@@ -2243,6 +2316,7 @@ TLSExtension._universalExtensions = {
     ExtensionType.record_size_limit: RecordSizeLimitExtension,
     ExtensionType.session_ticket: SessionTicketExtension,
     ExtensionType.compress_certificate: CompressedCertificateExtension,
+    ExtensionType.tls_flags: TLSFlagsExtension,
     ExtensionType.delegated_credential: DelegatedCredentialExtension
 }
 

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -27,8 +27,9 @@ from tlslite.extensions import TLSExtension, SNIExtension, NPNExtension,\
         PreSharedKeyExtension, PskIdentity, SrvPreSharedKeyExtension, \
         PskKeyExchangeModesExtension, CookieExtension, VarBytesExtension, \
         HeartbeatExtension, IntExtension, RecordSizeLimitExtension, \
-        SessionTicketExtension, CompressedCertificateExtension
-from tlslite.utils.codec import Parser, Writer
+        SessionTicketExtension, CompressedCertificateExtension, \
+        TLSFlagsExtension
+from tlslite.utils.codec import Parser, Writer, DecodeError
 from tlslite.constants import NameType, ExtensionType, GroupName,\
         ECPointFormat, HashAlgorithm, SignatureAlgorithm, \
         CertificateStatusType, SignatureScheme, HeartbeatMode, CertificateType
@@ -2972,5 +2973,169 @@ class TestCompressedCertificateExtension(unittest.TestCase):
             "CompressedCertificateExtension(algorithms=[zlib, brotli, zstd])")
 
 
-if __name__ == '__main__':
+class TestTLSFlagsExtension(unittest.TestCase):
+    def test___init__(self):
+        ext = TLSFlagsExtension()
+
+        self.assertIsNotNone(ext)
+        self.assertEqual(ext.flags, set())
+        self.assertEqual(ext.extType, ExtensionType.tls_flags)
+
+    def test_create(self):
+        ext = TLSFlagsExtension()
+        ext = ext.create([1, 5])
+
+        self.assertIsInstance(ext, TLSFlagsExtension)
+        self.assertEqual(ext.flags, set([1, 5]))
+
+    def test_create_with_low_flag(self):
+        ext = TLSFlagsExtension().create([3])
+
+        self.assertEqual(ext.flags, set([3]))
+
+    def test_create_with_highest_bit_flag(self):
+        ext = TLSFlagsExtension().create([2039])
+
+        self.assertEqual(ext.flags, set([2039]))
+
+    def test_create_with_invalid_out_of_range_bit_flag(self):
+        with self.assertRaises(ValueError):
+            TLSFlagsExtension().create([2040])
+
+    def test_create_with_invalid_empty_flag(self):
+        with self.assertRaises(ValueError):
+            TLSFlagsExtension().create([])
+
+    def test_create_with_invalid_negative_flag(self):
+        with self.assertRaises(ValueError):
+            TLSFlagsExtension().create([-1])
+
+    def test_write_lowest_bit(self):
+        ext = TLSFlagsExtension().create([0])
+
+        # type, length, then length prefix (1) + bit 0 set
+        self.assertEqual(bytearray([
+            0, 0x3e,  # type
+            0, 2,  # ext length
+            1, 0b00000001]),  # length prefix (1) + bit 0
+            ext.write())
+
+    def test_write_highest_bit(self):
+        ext = TLSFlagsExtension().create([2039])
+
+        self.assertEqual(bytearray([
+            0, 0x3e,  # type
+            0x01, 0x00,  # ext length (256)
+            0xff,  # length prefix (255)
+        ] + [0b0] * 254 + [ # 254 zeroes
+            0b10000000]),  # highest bit of the last byte set
+            ext.write())
+
+    def test_write_multiple_low_flags(self):
+        ext = TLSFlagsExtension().create([1, 5])
+
+        self.assertEqual(bytearray([
+            0, 0x3e,  # type (62)
+            0, 2,  # ext length
+            1, 0b00100010]),  # length prefix (1) + bits 1 and 5
+            ext.write())
+
+    def test_write_multiple_flags(self):
+        ext = TLSFlagsExtension().create([3, 5, 23])
+
+        self.assertEqual(bytearray([
+            0, 0x3e,  # type
+            0, 4,  # ext length
+            3,  # length prefix (3)
+            0b00101000, 0b00000000, 0b10000000]),  # bits 3, 5 and 23
+            ext.write())
+
+    def test_write_invalid_uninitialized(self):
+        uninitialized = TLSFlagsExtension()
+        with self.assertRaises(ValueError):
+            uninitialized.write()
+
+    def test_parse_single_byte(self):
+        parser = Parser(bytearray([
+            0, 0x3e,  # type
+            0, 2,  # ext length
+            1, 0b00100010]))  # length prefix (1) + bits 1 and 5
+
+        ext = TLSExtension().parse(parser)
+
+        self.assertIsInstance(ext, TLSFlagsExtension)
+        self.assertEqual(ext.flags, set([1, 5]))
+
+    def test_parse_multi_byte(self):
+        parser = Parser(bytearray([
+            0, 0x3e,  # type
+            0, 4,  # ext length
+            3, 0b00101000, 0b00000000, 0b10000000]))  # (3) + bits 3, 5 and 23
+
+        ext = TLSExtension().parse(parser)
+
+        self.assertIsInstance(ext, TLSFlagsExtension)
+        self.assertEqual(ext.flags, set([3, 5, 23]))
+
+    def test_parse_lowest_bit(self):
+        parser = Parser(bytearray([
+            0, 0x3e,  # type
+            0, 2,  # ext length
+            1, 0b00000001]))  # length prefix (1) + bit 0
+
+        ext = TLSExtension().parse(parser)
+
+        self.assertIsInstance(ext, TLSFlagsExtension)
+        self.assertEqual(ext.flags, set([0]))
+
+    def test_parse_highest_bit(self):
+        data = [0xff] + [0] * 254 + [0b10000000]
+        parser = Parser(bytearray([0, 0x3e, 1, 0b0] + data))
+
+        ext = TLSExtension().parse(parser)
+
+        self.assertIsInstance(ext, TLSFlagsExtension)
+        self.assertEqual(ext.flags, set([2039]))
+
+    def test_parse_with_invalid_empty_payload(self):
+        parser = Parser(bytearray([0, 0x3e, 0, 1, 0b0]))
+
+        with self.assertRaises(DecodeError):
+            TLSExtension().parse(parser)
+
+    def test_parse_with_invalid_all_zero(self):
+        parser = Parser(bytearray([0, 0x3e, 0, 2, 1, 0b0]))
+
+        with self.assertRaises(DecodeError):
+            TLSExtension().parse(parser)
+
+    def test_parse_with_invalid_trailing_zero(self):
+        parser = Parser(bytearray([0, 0x3e, 0, 3, 3, 0b1, 0b1, 0b0]))
+
+        with self.assertRaises(DecodeError):
+            TLSExtension().parse(parser)
+
+    def test_parse_with_invalid_trailing_data(self):
+        parser = Parser(bytearray([0, 0x3e, 0, 3, 1, 0b1, 0xff]))
+
+        with self.assertRaises(DecodeError):
+            TLSExtension().parse(parser)
+
+    def test_round_trip(self):
+        ext = TLSFlagsExtension().create([0, 7, 8, 15, 2039])
+
+        p = Parser(ext.write())
+        ext2 = TLSExtension().parse(p)
+
+        self.assertIsInstance(ext2, TLSFlagsExtension)
+        self.assertEqual(ext2.flags, set([0, 7, 8, 15, 2039]))
+
+    def test___repr__(self):
+        ext = TLSFlagsExtension().create([5, 1])
+
+        self.assertEqual(repr(ext),
+                         "TLSFlagsExtension(flags={1, 5})")
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add support for tls_flags extension as defined in https://datatracker.ietf.org/doc/draft-ietf-tls-tlsflags/17

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlslite-ng/562)
<!-- Reviewable:end -->
